### PR TITLE
[ENG-90] ci: enable dependabot for this repository

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
Dependabot is a github feature which will check dependencies for updates or vulnerabilities, and then auto-create PRs to upgrade. It saves a lot of busywork and generally lets us stay up to date with our upstream dependencies.

See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file

This PR enables this feature and runs it once per day.
