### PR TITLE
[ENG-164] feat: Add the generate-request-token command

### DIFF
--- a/cmd/token.go
+++ b/cmd/token.go
@@ -16,7 +16,7 @@ import (
 var tokenCmd = &cobra.Command{
 	Use:    "generate-request-token",
 	Short:  "Generate a request token",
-	Long:   "Generate a JWT token to be used for HTTP requests",
+	Long:   "Generate a JWT token to be used for HTTP requests, and prints it. This command is useful for testing purposes.",
 	Hidden: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		contents, err := os.ReadFile(getJwtPath())


### PR DESCRIPTION
As part of setting up AuthN / AuthZ for our kubernetes-based service, I needed to generate some JWT tokens for testing. This PR shows how I did that. If we want to merge it so everyone has it, that's fine. It's marked as hidden, so normal users probably won't know or care that it's there.

There's no security risk:
* Users will need to run `amp login` before calling this command.
* The CLI will be making these calls on behalf of users for all authenticated calls (regardless of whether this PR is merged or not) - meaning nothing extra gets leaked.
* The tokens generated time out after about 1 minute, so the lifetime is pretty small.
* The command is hidden, more for aesthetic reasons than for security. But if you believe in security through obscurity, then I suppose add that to the list of reasons.

Seems useful for me but I could see reasons for not including it.