### PR TITLE
[ENG-203] feat: Finish implementing `amp deploy` command

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,8 +18,9 @@ builds:
       - -X github.com/amp-labs/cli/vars.Stage=prod
       - -X github.com/amp-labs/cli/vars.BuildDate={{.Timestamp}}
       - -X github.com/amp-labs/cli/vars.Version={{.Version}}
-      - -X github.com/amp-labs/cli/vars.ClerkRootURL=https://clerk.withampersand.com/
-      - -X github.com/amp-labs/cli/vars.LoginURL=https://ampersand-cli-auth-prod.web.app
+      - -X github.com/amp-labs/cli/vars.ClerkRootURL=https://clerk.withampersand.com
+      - -X github.com/amp-labs/cli/vars.LoginURL=https://cli-signin.withampersand.com
+      - -X github.com/amp-labs/cli/vars.ApiURL=https://api.withampersand.com
       - -X github.com/amp-labs/cli/vars.GCSBucket=ampersand-prod-deploy-uploads
       - -X github.com/amp-labs/cli/vars.GCSKey=AIzaSyDGWb5ncKSvkeNl5ZO_zVnP_5KdiKjo-i4
 archives:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -5,7 +5,7 @@ tasks:
         desc: Build the CLI (don't call directly)
         cmds:
         - go generate ./...
-        - CGO_ENABLED=0 go build -ldflags="-X {{.PKG}}.CommitID={{.GIT_COMMIT}} -X {{.PKG}}.Branch={{.GIT_BRANCH}} -X {{.PKG}}.Stage={{.STAGE}} -X '{{.PKG}}.BuildDate={{.BUILD_DATE}}' -X {{.PKG}}.Version={{.VERSION}} -X {{.PKG}}.ClerkRootURL={{.CLERK_URL}} -X {{.PKG}}.LoginURL={{.LOGIN_URL}} -X {{.PKG}}.GCSBucket={{.GCS_BUCKET}} -X {{.PKG}}.GCSKey={{.GCS_KEY}}" -o bin/amp{{if eq OS "windows"}}.exe{{end}} main.go
+        - CGO_ENABLED=0 go build -ldflags="-X {{.PKG}}.CommitID={{.GIT_COMMIT}} -X {{.PKG}}.Branch={{.GIT_BRANCH}} -X {{.PKG}}.Stage={{.STAGE}} -X '{{.PKG}}.BuildDate={{.BUILD_DATE}}' -X {{.PKG}}.Version={{.VERSION}} -X {{.PKG}}.ClerkRootURL={{.CLERK_URL}} -X {{.PKG}}.LoginURL={{.LOGIN_URL}} -X {{.PKG}}.ApiURL={{.API_URL}} -X {{.PKG}}.GCSBucket={{.GCS_BUCKET}} -X {{.PKG}}.GCSKey={{.GCS_KEY}}" -o bin/amp{{if eq OS "windows"}}.exe{{end}} main.go
         vars:
             GIT_COMMIT:
                 sh: git log -n 1 --format=%H
@@ -21,8 +21,9 @@ tasks:
         cmds:
             - task: do_build
               vars:
-                  CLERK_URL: https://welcomed-snapper-45.clerk.accounts.dev/
+                  CLERK_URL: https://welcomed-snapper-45.clerk.accounts.dev
                   LOGIN_URL: https://ampersand-cli-auth-dev.web.app
+                  API_URL: https://dev-api.withampersand.com
                   GCS_BUCKET: ampersand-dev-deploy-uploads
                   GCS_KEY: "AIzaSyBvOQ41f7igI0wtclU0JgqBKfPtOluyjpg"
                   STAGE: dev
@@ -32,8 +33,9 @@ tasks:
         cmds:
             - task: do_build
               vars:
-                  CLERK_URL: https://welcomed-snapper-45.clerk.accounts.dev/
+                  CLERK_URL: https://welcomed-snapper-45.clerk.accounts.dev
                   LOGIN_URL: https://ampersand-cli-auth-stag.web.app
+                  API_URL: https://staging-api.withampersand.com
                   GCS_BUCKET: ampersand-staging-deploy-uploads
                   GCS_KEY: "AIzaSyBCgKKMfPJLm4e6k2tg_xJO5epVI1I2KK4"
                   STAGE: staging
@@ -43,8 +45,9 @@ tasks:
         cmds:
             - task: do_build
               vars:
-                  CLERK_URL: https://clerk.withampersand.com/
-                  LOGIN_URL: https://ampersand-cli-auth-prod.web.app
+                  CLERK_URL: https://clerk.withampersand.com
+                  LOGIN_URL: https://cli-signin.withampersand.com
+                  API_URL: https://api.withampersand.com
                   GCS_BUCKET: ampersand-prod-deploy-uploads
                   GCS_KEY: "AIzaSyDGWb5ncKSvkeNl5ZO_zVnP_5KdiKjo-i4"
                   STAGE: prod

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -1,14 +1,20 @@
 package cmd
 
 import (
+	"context"
+	"github.com/amp-labs/cli/flags"
 	"path/filepath"
+	"strings"
 
 	"github.com/amp-labs/cli/files"
 	"github.com/amp-labs/cli/logger"
+	"github.com/amp-labs/cli/request"
 	"github.com/amp-labs/cli/storage"
 	"github.com/amp-labs/cli/utils"
 	"github.com/spf13/cobra"
 )
+
+var apiKey string
 
 var deployCmd = &cobra.Command{ //nolint:gochecknoglobals
 	Use:   "deploy <sourceFolderPath>",
@@ -16,6 +22,7 @@ var deployCmd = &cobra.Command{ //nolint:gochecknoglobals
 	Long:  "Deploy changes to amp.yaml file.",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		projectId := flags.GetProjectId()
 		path := args[0]
 		workingDir := utils.GetWorkingDir()
 		folderName := filepath.ToSlash(filepath.Join(workingDir, path))
@@ -32,10 +39,29 @@ var deployCmd = &cobra.Command{ //nolint:gochecknoglobals
 			logger.FatalErr("Unable to upload to Google Cloud Storage", err)
 		}
 		logger.Debugf("Uploaded to %v", gcsURL)
-		logger.Info("Successfully deployed changes to your integrations ....")
+		integrations, err := request.NewAPIClient(projectId, &apiKey).
+			BatchUpsertIntegrations(context.Background(), request.BatchUpsertIntegrationsParams{SourceZipURL: gcsURL})
+
+		if err != nil {
+			logger.FatalErr("Unable to deploy integrations", err)
+		}
+
+		names := make([]string, len(integrations))
+		for idx, i := range integrations {
+			names[idx] = i.Name
+		}
+
+		if len(names) == 0 {
+			logger.Infof("No integrations were found in the source file.")
+		} else if len(names) == 1 {
+			logger.Infof("Successfully deployed your integration %s.", names[0])
+		} else {
+			logger.Infof("Successfully deployed your integrations %s.", strings.Join(names, ","))
+		}
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(deployCmd)
+	deployCmd.Flags().StringVarP(&apiKey, "key", "k", "", "Ampersand API key")
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"path/filepath"
 	"strings"
 
@@ -40,7 +39,7 @@ var deployCmd = &cobra.Command{ //nolint:gochecknoglobals
 		}
 		logger.Debugf("Uploaded to %v", gcsURL)
 		integrations, err := request.NewAPIClient(projectId, &apiKey).
-			BatchUpsertIntegrations(context.Background(), request.BatchUpsertIntegrationsParams{SourceZipURL: gcsURL})
+			BatchUpsertIntegrations(cmd.Context(), request.BatchUpsertIntegrationsParams{SourceZipURL: gcsURL})
 		if err != nil {
 			logger.FatalErr("Unable to deploy integrations", err)
 		}
@@ -51,16 +50,17 @@ var deployCmd = &cobra.Command{ //nolint:gochecknoglobals
 		}
 
 		if len(names) == 0 {
-			logger.Infof("No integrations were found in the source file.")
+			logger.Infof("No integrations were found in the source file.\n")
 		} else if len(names) == 1 {
-			logger.Infof("Successfully deployed your integration %s.", names[0])
+			logger.Infof("Successfully deployed your integration %s.\n", names[0])
 		} else {
-			logger.Infof("Successfully deployed your integrations %s.", strings.Join(names, ","))
+			logger.Infof("Successfully deployed your integrations %s.\n", strings.Join(names, ", "))
 		}
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(deployCmd)
+	// TODO: use viper to bind this to an env variable so it can be set in CI/CD environments or in bashrc/zshrc.
 	deployCmd.Flags().StringVarP(&apiKey, "key", "k", "", "Ampersand API key")
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -2,11 +2,11 @@ package cmd
 
 import (
 	"context"
-	"github.com/amp-labs/cli/flags"
 	"path/filepath"
 	"strings"
 
 	"github.com/amp-labs/cli/files"
+	"github.com/amp-labs/cli/flags"
 	"github.com/amp-labs/cli/logger"
 	"github.com/amp-labs/cli/request"
 	"github.com/amp-labs/cli/storage"
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var apiKey string
+var apiKey string //nolint:gochecknoglobals
 
 var deployCmd = &cobra.Command{ //nolint:gochecknoglobals
 	Use:   "deploy <sourceFolderPath>",
@@ -41,7 +41,6 @@ var deployCmd = &cobra.Command{ //nolint:gochecknoglobals
 		logger.Debugf("Uploaded to %v", gcsURL)
 		integrations, err := request.NewAPIClient(projectId, &apiKey).
 			BatchUpsertIntegrations(context.Background(), request.BatchUpsertIntegrationsParams{SourceZipURL: gcsURL})
-
 		if err != nil {
 			logger.FatalErr("Unable to deploy integrations", err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,8 +33,4 @@ func init() {
 	if err != nil {
 		logger.FatalErr("unable to initialize flags: ", err)
 	}
-
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/flags/config.go
+++ b/flags/config.go
@@ -9,15 +9,22 @@ type FlagConfig struct {
 	DebugMode bool
 }
 
-var Config FlagConfig //nolint:gochecknoglobals
-
-// TODO: Will need a better implementation with multiple flags.
 func Init(rootCmd *cobra.Command) error {
-	rootCmd.PersistentFlags().BoolVarP(&Config.DebugMode, "debug", "d", false, "Enable debug logging mode")
-
-	return viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug"))
+	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Enable debug logging mode")
+	rootCmd.PersistentFlags().StringP("project", "p", "", "Ampersand project ID")
+	if err := viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug")); err != nil {
+		return err
+	}
+	if err := viper.BindPFlag("project", rootCmd.PersistentFlags().Lookup("project")); err != nil {
+		return err
+	}
+	return nil
 }
 
 func GetDebugMode() bool {
 	return viper.GetBool("debug")
+}
+
+func GetProjectId() string {
+	return viper.GetString("project")
 }

--- a/flags/config.go
+++ b/flags/config.go
@@ -12,12 +12,15 @@ type FlagConfig struct {
 func Init(rootCmd *cobra.Command) error {
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Enable debug logging mode")
 	rootCmd.PersistentFlags().StringP("project", "p", "", "Ampersand project ID")
+
 	if err := viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug")); err != nil {
 		return err
 	}
+
 	if err := viper.BindPFlag("project", rootCmd.PersistentFlags().Lookup("project")); err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/request/api.go
+++ b/request/api.go
@@ -3,11 +3,12 @@ package request
 import (
 	"context"
 	"fmt"
+
 	"github.com/amp-labs/cli/logger"
 	"github.com/amp-labs/cli/vars"
 )
 
-var API_VERSION = "v1"
+var API_VERSION = "v1" //nolint:gochecknoglobals
 
 type APIClient struct {
 	Root          string
@@ -22,6 +23,7 @@ func NewAPIClient(projectId string, key *string) *APIClient {
 		// so it doesn't need to be provided with each command.
 		logger.Fatal("Must provide a project ID in the --project flag")
 	}
+
 	return &APIClient{
 		Root:          fmt.Sprintf("%s/%s", vars.ApiURL, API_VERSION),
 		ProjectId:     projectId,
@@ -38,19 +40,26 @@ type Integration struct {
 	Name string `json:"name"`
 }
 
-func (c *APIClient) BatchUpsertIntegrations(ctx context.Context, reqParams BatchUpsertIntegrationsParams) ([]Integration, error) {
+func (c *APIClient) BatchUpsertIntegrations(
+	ctx context.Context, reqParams BatchUpsertIntegrationsParams,
+) ([]Integration, error) {
 	url := fmt.Sprintf("%s/projects/%s/integrations:batch", c.Root, c.ProjectId)
+
 	var integrations []Integration
+
 	var err error
+
 	if c.APIKey != nil && *c.APIKey != "" {
 		header := Header{Key: "X-Api-Key", Value: *c.APIKey}
-		_, err = c.RequestClient.Put(ctx, url, reqParams, &integrations, header)
+		_, err = c.RequestClient.Put(ctx, url, reqParams, &integrations, header) //nolint:bodyclose
 	} else {
 		// TODO: Default to token authentication and set Authorization header, instead of failing.
 		logger.Fatal("Must provide an API key in the --key flag")
 	}
+
 	if err != nil {
 		return nil, err
 	}
+
 	return integrations, nil
 }

--- a/request/api.go
+++ b/request/api.go
@@ -1,0 +1,56 @@
+package request
+
+import (
+	"context"
+	"fmt"
+	"github.com/amp-labs/cli/logger"
+	"github.com/amp-labs/cli/vars"
+)
+
+var API_VERSION = "v1"
+
+type APIClient struct {
+	Root          string
+	ProjectId     string
+	APIKey        *string
+	RequestClient *RequestClient
+}
+
+func NewAPIClient(projectId string, key *string) *APIClient {
+	if projectId == "" {
+		// TODO: add the ability to set projectId context via a command
+		// so it doesn't need to be provided with each command.
+		logger.Fatal("Must provide a project ID in the --project flag")
+	}
+	return &APIClient{
+		Root:          fmt.Sprintf("%s/%s", vars.ApiURL, API_VERSION),
+		ProjectId:     projectId,
+		APIKey:        key,
+		RequestClient: NewRequestClient(),
+	}
+}
+
+type BatchUpsertIntegrationsParams struct {
+	SourceZipURL string `json:"sourceZipUrl"`
+}
+
+type Integration struct {
+	Name string `json:"name"`
+}
+
+func (c *APIClient) BatchUpsertIntegrations(ctx context.Context, reqParams BatchUpsertIntegrationsParams) ([]Integration, error) {
+	url := fmt.Sprintf("%s/projects/%s/integrations:batch", c.Root, c.ProjectId)
+	var integrations []Integration
+	var err error
+	if c.APIKey != nil && *c.APIKey != "" {
+		header := Header{Key: "X-Api-Key", Value: *c.APIKey}
+		_, err = c.RequestClient.Put(ctx, url, reqParams, &integrations, header)
+	} else {
+		// TODO: Default to token authentication and set Authorization header, instead of failing.
+		logger.Fatal("Must provide an API key in the --key flag")
+	}
+	if err != nil {
+		return nil, err
+	}
+	return integrations, nil
+}

--- a/request/request.go
+++ b/request/request.go
@@ -6,10 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/amp-labs/cli/logger"
 	"io"
 	"net/http"
 	"net/http/httputil"
+
+	"github.com/amp-labs/cli/logger"
 )
 
 type RequestClient struct {
@@ -55,7 +56,6 @@ func (c *RequestClient) Post(ctx context.Context,
 var ErrNone200Status = errors.New("error response from API")
 
 func (c *RequestClient) makeRequestAndParseResult(req *http.Request, result any) (*http.Response, error) {
-
 	dump, _ := httputil.DumpRequest(req, false)
 	logger.Debugf("\n>>> API REQUEST:\n%v>>> END OF API REQUEST\n", string(dump))
 

--- a/request/request.go
+++ b/request/request.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 
 	"github.com/amp-labs/cli/logger"
@@ -99,7 +98,7 @@ func makeJSONPutRequest(ctx context.Context, url string, headers []Header, body 
 		return nil, fmt.Errorf("request body is not valid JSON, body is %v:\n%w", body, err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewBuffer(jBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(jBody))
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %w", err)
 	}
@@ -135,7 +134,7 @@ func (c *RequestClient) sendRequest(req *http.Request) (*http.Response, []byte, 
 	defer func() {
 		if res != nil && res.Body != nil {
 			if closeErr := res.Body.Close(); closeErr != nil {
-				slog.Warn("unable to close response body", "error", closeErr)
+				logger.Debugf("unable to close response body %v", closeErr)
 			}
 		}
 	}()

--- a/request/request.go
+++ b/request/request.go
@@ -6,10 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/amp-labs/cli/logger"
 	"io"
 	"log/slog"
 	"net/http"
+
+	"github.com/amp-labs/cli/logger"
 )
 
 type RequestClient struct {
@@ -35,6 +36,7 @@ func (c *RequestClient) Put(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+
 	return c.makeRequestAndParseResult(req, result)
 }
 
@@ -47,6 +49,7 @@ func (c *RequestClient) Post(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+
 	return c.makeRequestAndParseResult(req, result)
 }
 
@@ -54,17 +57,22 @@ var ErrNone200Status = errors.New("error response from API")
 
 func (c *RequestClient) makeRequestAndParseResult(req *http.Request, result any) (*http.Response, error) {
 	logger.Debugf(">>> API REQUEST:\n%+v\n", req)
+
 	res, payload, err := c.sendRequest(req)
 	if err != nil {
 		return nil, err
 	}
+
 	logger.Debugf("<<< API RESPONSE:\n%+v\n", res)
+
 	if res.StatusCode < 200 || res.StatusCode > 299 {
 		return res, fmt.Errorf("%w: HTTP Status %s", ErrNone200Status, res.Status)
 	}
+
 	if err := json.Unmarshal(payload, result); err != nil {
 		return nil, err
 	}
+
 	return res, nil
 }
 
@@ -92,7 +100,6 @@ func makeJSONPutRequest(ctx context.Context, url string, headers []Header, body 
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewBuffer(jBody))
-
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %w", err)
 	}

--- a/request/request.go
+++ b/request/request.go
@@ -1,0 +1,137 @@
+package request
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/amp-labs/cli/logger"
+	"io"
+	"log/slog"
+	"net/http"
+)
+
+type RequestClient struct {
+	Client *http.Client
+}
+
+// Header is a key/value pair that can be added to a request.
+type Header struct {
+	Key   string
+	Value string
+}
+
+func NewRequestClient() *RequestClient {
+	return &RequestClient{Client: http.DefaultClient}
+}
+
+func (c *RequestClient) Put(ctx context.Context,
+	url string, reqBody any, result any, headers ...Header,
+) (*http.Response, error) {
+	req, err := makeJSONPutRequest(ctx, url, headers, reqBody)
+	if err != nil {
+		return nil, err
+	}
+	return c.makeRequestAndParseResult(req, result)
+}
+
+func (c *RequestClient) Post(ctx context.Context,
+	url string, reqBody any, result any, headers ...Header,
+) (*http.Response, error) {
+	req, err := makeJSONPostRequest(ctx, url, headers, reqBody)
+	if err != nil {
+		return nil, err
+	}
+	return c.makeRequestAndParseResult(req, result)
+}
+
+var ErrNone200Status = errors.New("error response from API")
+
+func (c *RequestClient) makeRequestAndParseResult(req *http.Request, result any) (*http.Response, error) {
+	logger.Debugf(">>> API REQUEST:\n%+v\n", req)
+	res, payload, err := c.sendRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	logger.Debugf("<<< API RESPONSE:\n%+v\n", res)
+	if res.StatusCode < 200 || res.StatusCode > 299 {
+		return res, fmt.Errorf("%w: HTTP Status %s", ErrNone200Status, res.Status)
+	}
+	if err := json.Unmarshal(payload, result); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func makeJSONPostRequest(ctx context.Context, url string, headers []Header, body any) (*http.Request, error) {
+	jBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("request body is not valid JSON, body is %v:\n%w", body, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jBody))
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	headers = append(headers, Header{Key: "Content-Type", Value: "application/json"})
+	req.ContentLength = int64(len(jBody))
+
+	return addAcceptJSONHeaders(req, headers)
+}
+
+func makeJSONPutRequest(ctx context.Context, url string, headers []Header, body any) (*http.Request, error) {
+	jBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("request body is not valid JSON, body is %v:\n%w", body, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewBuffer(jBody))
+
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	headers = append(headers, Header{Key: "Content-Type", Value: "application/json"})
+	req.ContentLength = int64(len(jBody))
+
+	return addAcceptJSONHeaders(req, headers)
+}
+
+func addAcceptJSONHeaders(req *http.Request, headers []Header) (*http.Request, error) {
+	// Request JSON
+	req.Header.Add("Accept", "application/json")
+
+	// Apply any custom headers
+	for _, hdr := range headers {
+		req.Header.Add(hdr.Key, hdr.Value)
+	}
+
+	return req, nil
+}
+
+func (c *RequestClient) sendRequest(req *http.Request) (*http.Response, []byte, error) {
+	// Send the request
+	res, err := c.Client.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error sending request: %w", err)
+	}
+
+	// Read the response body
+	body, err := io.ReadAll(res.Body)
+
+	defer func() {
+		if res != nil && res.Body != nil {
+			if closeErr := res.Body.Close(); closeErr != nil {
+				slog.Warn("unable to close response body", "error", closeErr)
+			}
+		}
+	}()
+
+	if err != nil {
+		return nil, nil, fmt.Errorf("error reading response body: %w", err)
+	}
+
+	return res, body, nil
+}

--- a/request/request.go
+++ b/request/request.go
@@ -26,6 +26,8 @@ func NewRequestClient() *RequestClient {
 	return &RequestClient{Client: http.DefaultClient}
 }
 
+// Put makes a PUT request to the desired URL, and unmarshalls the
+// response body into `result`.
 func (c *RequestClient) Put(ctx context.Context,
 	url string, reqBody any, result any, headers ...Header,
 ) (*http.Response, error) {
@@ -36,6 +38,8 @@ func (c *RequestClient) Put(ctx context.Context,
 	return c.makeRequestAndParseResult(req, result)
 }
 
+// Post makes a POST request to the desired URL, and unmarshalls the
+// response body into `result`.
 func (c *RequestClient) Post(ctx context.Context,
 	url string, reqBody any, result any, headers ...Header,
 ) (*http.Response, error) {

--- a/vars/vars.go
+++ b/vars/vars.go
@@ -6,6 +6,7 @@ package vars
 var (
 	ClerkRootURL = "unset" //nolint:gochecknoglobals
 	LoginURL     = "unset" //nolint:gochecknoglobals
+	ApiURL       = "unset" //nolint:gochecknoglobals
 	Stage        = "unset" //nolint:gochecknoglobals
 	CommitID     = "unset" //nolint:gochecknoglobals
 	Version      = "unset" //nolint:gochecknoglobals


### PR DESCRIPTION
This PR finishes the implementation of the amp deploy command, so that after the source folder is uploaded to GCS, it makes a `batchUpsertIntegrations` call (using API key authentication as the only supported method for now, later we'll also support user authentication). I introduced an API client as well as a request client. I didn't refactor the cmd/login.go code to use the new request client yet, because that code will likely need to be re-written pretty substantially to work with Clerk in prod. 

One integration:
<img width="1114" alt="Screen Shot 2023-09-29 at 4 47 21 PM" src="https://github.com/amp-labs/cli/assets/3990804/247e2f56-c544-4bd9-a820-52e8709cff08">


Multiple integrations:
<img width="1111" alt="Screen Shot 2023-09-29 at 4 45 35 PM" src="https://github.com/amp-labs/cli/assets/3990804/80798db2-545b-4cfd-bfbd-0220885ebeb4">


With debug flag:
<img width="1112" alt="Screen Shot 2023-09-29 at 4 46 02 PM" src="https://github.com/amp-labs/cli/assets/3990804/f07a26f5-8e77-4af4-baac-41e010052900">

