### PR TITLE
feat: add AMP_API_KEY env var

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -13,7 +13,8 @@ tasks:
                 sh: git rev-parse --abbrev-ref HEAD
             BUILD_DATE:
                 sh: date -u '+%Y-%m-%d %I:%M%p'
-            VERSION: 0.1
+            VERSION:
+                sh: git tag --points-at HEAD | sed 's/^v//'
             PKG: github.com/amp-labs/cli/vars
 
     build-dev:

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -27,7 +27,7 @@ func Debugf(msg string, a ...any) {
 }
 
 func Fatal(msg string) {
-	Debug(msg)
+	Infof(msg)
 	os.Exit(1)
 }
 


### PR DESCRIPTION
This PR lets the user set an environment variable (`AMP_API_KEY`) as an alternative to explicitly passing in a key via the `--key` flag. This is done using viper.

It also fixes a few small issues with the code, including how the version number is passed in.