### PR TITLE
feat: Print out Revision ID after deploying

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"path/filepath"
-	"strings"
 
 	"github.com/amp-labs/cli/files"
 	"github.com/amp-labs/cli/flags"
@@ -47,16 +46,21 @@ var deployCmd = &cobra.Command{ //nolint:gochecknoglobals
 		}
 
 		names := make([]string, len(integrations))
+		revisionIds := make([]string, len(integrations))
 		for idx, i := range integrations {
 			names[idx] = i.Name
+			revisionIds[idx] = i.LatestRevision.Id
 		}
 
 		if len(names) == 0 {
 			logger.Infof("No integrations were found in the source file.\n")
 		} else if len(names) == 1 {
-			logger.Infof("Successfully deployed your integration %s.\n", names[0])
+			logger.Infof("Successfully deployed your integration %s (revision ID: %s).\n", names[0], revisionIds[0])
 		} else {
-			logger.Infof("Successfully deployed your integrations %s.\n", strings.Join(names, ", "))
+			logger.Info("Successfully deployed your integrations:")
+			for _, i := range integrations {
+				logger.Infof("- %s (revision ID: %s)", i.Name, i.LatestRevision.Id)
+			}
 		}
 	},
 }

--- a/request/api.go
+++ b/request/api.go
@@ -37,7 +37,12 @@ type BatchUpsertIntegrationsParams struct {
 }
 
 type Integration struct {
-	Name string `json:"name"`
+	Name           string    `json:"name"`
+	LatestRevision *Revision `json:"latestRevision"`
+}
+
+type Revision struct {
+	Id string `json:"id"`
 }
 
 func (c *APIClient) BatchUpsertIntegrations(


### PR DESCRIPTION
Since the builder needs to know the revision ID of the integration to import installations, this PR modifies the CLI to print it out after deployment:

<img width="1369" alt="Screen Shot 2023-10-10 at 3 10 50 PM" src="https://github.com/amp-labs/cli/assets/3990804/0503cd97-b49a-4ab4-ab0a-593bb4cbcfbe">
