### PR TITLE
[ENG-366] feat: Hide the login and logout command

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -234,9 +234,10 @@ const ReadHeaderTimeoutSeconds = 3
 
 // loginCmd represents the login command.
 var loginCmd = &cobra.Command{ //nolint:gochecknoglobals
-	Use:   "login",
-	Short: "Log in to an Ampersand account",
-	Long:  "Log in to an Ampersand account.",
+	Use:    "login",
+	Short:  "Log in to an Ampersand account",
+	Long:   "Log in to an Ampersand account.",
+	Hidden: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		needLogin := false
 		path := getJwtPath()

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -10,9 +10,10 @@ import (
 
 // logoutCmd represents the logout command.
 var logoutCmd = &cobra.Command{ //nolint:gochecknoglobals
-	Use:   "logout",
-	Short: "Log out of an ampersand account",
-	Long:  "Log out of an ampersand account.",
+	Use:    "logout",
+	Short:  "Log out of an ampersand account",
+	Long:   "Log out of an ampersand account.",
+	Hidden: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		path := getJwtPath()
 		_, err := os.Stat(path)


### PR DESCRIPTION
Since we're using API keys rather than clerk logins (for the MVP) we decided to hide the login command. I also hid the logout command since it's related.