### PR TITLE
[ENG-548] fix: Get clerk auth working properly in staging

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -44,8 +44,8 @@ tasks:
         cmds:
             - task: do_build
               vars:
-                  CLERK_URL: https://welcomed-snapper-45.clerk.accounts.dev
-                  LOGIN_URL: https://ampersand-cli-auth-stag.web.app
+                  CLERK_URL: https://clerk.withampersand.com
+                  LOGIN_URL: https://staging-cli-signin.withampersand.com
                   API_URL: https://staging-api.withampersand.com
                   STAGE: staging
 


### PR DESCRIPTION
This PR makes the CLI use the correct endpoints for staging.

* The auth cli now has a proper DNS name
* The clerk endpoint is for (Clerk) prod, not (Clerk) dev -- which we decided is how (Ampersand) staging should be configured