### PR TITLE
[ENG-638] fix: Don't log a warning about bad cookie characters

### DIFF
--- a/clerk/clerk.go
+++ b/clerk/clerk.go
@@ -173,19 +173,20 @@ func FetchJwt(ctx context.Context) (string, error) { //nolint:funlen,cyclop
 		return "", fmt.Errorf("error creating request: %w", err)
 	}
 
-	for k, v := range clerkLogin.Cookies {
+	for cookieName, cookieValue := range clerkLogin.Cookies {
 		// This is doing the same thing that net/http does (filtering out
 		// invalid characters), but it's doing it in a way that's not
 		// going to log a noisy error message.
 		var sb strings.Builder
-		for _, r := range v {
-			if validCookieValueRune(r) {
-				sb.WriteRune(r)
+
+		for _, char := range cookieValue {
+			if validCookieValueRune(char) {
+				sb.WriteRune(char)
 			}
 		}
 
 		req.AddCookie(&http.Cookie{
-			Name:     k,
+			Name:     cookieName,
 			Value:    sb.String(),
 			Path:     "/",
 			Domain:   GetClerkDomain(),

--- a/clerk/clerk.go
+++ b/clerk/clerk.go
@@ -177,17 +177,21 @@ func FetchJwt(ctx context.Context) (string, error) { //nolint:funlen,cyclop
 		// This is doing the same thing that net/http does (filtering out
 		// invalid characters), but it's doing it in a way that's not
 		// going to log a noisy error message.
-		var sb strings.Builder
+		var builder strings.Builder
 
+		// See the function http.sanitizeCookieValue for where this
+		// logic comes from. It's not a verbatim copy, although
+		// validCookieValueRune is essentially identical to
+		// validCookieValueByte.
 		for _, char := range cookieValue {
 			if validCookieValueRune(char) {
-				sb.WriteRune(char)
+				builder.WriteRune(char)
 			}
 		}
 
 		req.AddCookie(&http.Cookie{
 			Name:     cookieName,
-			Value:    sb.String(),
+			Value:    builder.String(),
 			Path:     "/",
 			Domain:   GetClerkDomain(),
 			Secure:   true,


### PR DESCRIPTION
The go HTTP client is fairly strict when it comes to following the spec for cookies. Certain characters aren't allowed. If these characters are encountered, they get stripped out. Unfortunately, go also logs a warning using the log package. This is confusing for users. Worse, it's kinda hard to suppress. So this PR just filters the value before it gets to that block. Voila, no more log messages.