### PR TITLE
[ENG-527] chore: rename delete-integration and alias deploy:integraton

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -8,7 +8,7 @@ import (
 )
 
 var deleteCmd = &cobra.Command{ //nolint:gochecknoglobals
-	Use:   "delete-integration <integrationId>",
+	Use:   "delete:integration <integrationId>",
 	Short: "Delete integration",
 	Long:  "Delete integration",
 	Args:  cobra.ExactArgs(1),

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -18,11 +18,11 @@ import (
 )
 
 var deployCmd = &cobra.Command{ //nolint:gochecknoglobals
-	Use:   "deploy <sourceFolderPath>",
+	Use:     "deploy <sourceFolderPath>",
 	Aliases: []string{"deploy:integration"},
-	Short: "Deploy amp.yaml file",
-	Long:  "Deploy changes to amp.yaml file.",
-	Args:  cobra.ExactArgs(1),
+	Short:   "Deploy amp.yaml file",
+	Long:    "Deploy changes to amp.yaml file.",
+	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		projectId := flags.GetProjectId()
 		if projectId == "" {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -19,6 +19,7 @@ import (
 
 var deployCmd = &cobra.Command{ //nolint:gochecknoglobals
 	Use:   "deploy <sourceFolderPath>",
+	Aliases: []string{"deploy:integration"},
 	Short: "Deploy amp.yaml file",
 	Long:  "Deploy changes to amp.yaml file.",
 	Args:  cobra.ExactArgs(1),


### PR DESCRIPTION
We rename these commands to try to add more consistency to our CLI naming conventions.