### PR TITLE
[ENG-669] feat: add delete:installation command

### DIFF
--- a/cmd/delete_installation.go
+++ b/cmd/delete_installation.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"github.com/amp-labs/cli/flags"
+	"github.com/amp-labs/cli/logger"
+	"github.com/amp-labs/cli/request"
+	"github.com/spf13/cobra"
+)
+
+var deleteInstallationCmd = &cobra.Command{ //nolint:gochecknoglobals
+	Use:   "delete:installation <integrationId> <installationId>",
+	Short: "Delete installation",
+	Long:  "Delete installation",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		logger.Debug("Deleting installation")
+
+		integrationId := args[0]
+		installationId := args[1]
+		projectId := flags.GetProjectId()
+		if projectId == "" {
+			logger.Fatal("Must provide a project ID in the --project flag")
+		}
+
+		apiKey := flags.GetAPIKey()
+
+		err := request.NewAPIClient(projectId, &apiKey).
+			DeleteInstallation(cmd.Context(), integrationId, installationId)
+		if err != nil {
+			logger.FatalErr("Unable to delete installation", err)
+		}
+
+		logger.Info("Successfully deleted installation.")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(deleteInstallationCmd)
+}

--- a/cmd/delete_installation.go
+++ b/cmd/delete_installation.go
@@ -11,7 +11,7 @@ var deleteInstallationCmd = &cobra.Command{ //nolint:gochecknoglobals
 	Use:   "delete:installation <integrationId> <installationId>",
 	Short: "Delete installation",
 	Long:  "Delete installation",
-	Args:  cobra.ExactArgs(2),
+	Args:  cobra.ExactArgs(2), //nolint:gomnd
 	Run: func(cmd *cobra.Command, args []string) {
 		logger.Debug("Deleting installation")
 

--- a/cmd/delete_installation.go
+++ b/cmd/delete_installation.go
@@ -11,7 +11,7 @@ var deleteInstallationCmd = &cobra.Command{ //nolint:gochecknoglobals
 	Use:   "delete:installation <integrationId> <installationId>",
 	Short: "Delete installation",
 	Long:  "Delete installation",
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		logger.Debug("Deleting installation")
 

--- a/request/api.go
+++ b/request/api.go
@@ -118,6 +118,25 @@ func (c *APIClient) DeleteIntegration(ctx context.Context, integrationId string)
 	return nil
 }
 
+func (c *APIClient) DeleteInstallation(ctx context.Context, integrationId string, installationId string) error {
+	delURL := fmt.Sprintf(
+		"%s/projects/%s/integrations/%s/installations/%s", c.Root, c.ProjectId, integrationId, installationId,
+	)
+
+	auth, err := c.getAuthHeader(ctx)
+	if err != nil {
+		return err
+	}
+
+	if _, err := c.RequestClient.Delete(ctx, delURL, auth); err != nil { //nolint:bodyclose
+		return fmt.Errorf("error deleting installation: %w", err)
+	}
+
+	logger.Debugf("Deleted installation: %v", integrationId)
+
+	return nil
+}
+
 func (c *APIClient) getAuthHeader(ctx context.Context) (Header, error) {
 	if c.APIKey != nil && *c.APIKey != "" {
 		header := Header{Key: "X-Api-Key", Value: *c.APIKey}

--- a/request/api.go
+++ b/request/api.go
@@ -132,7 +132,7 @@ func (c *APIClient) DeleteInstallation(ctx context.Context, integrationId string
 		return fmt.Errorf("error deleting installation: %w", err)
 	}
 
-	logger.Debugf("Deleted installation: %v", integrationId)
+	logger.Debugf("Deleted installation: %v", installationId)
 
 	return nil
 }


### PR DESCRIPTION
Adds a command that is amp delete:installation integration-id installation-id --project=project-id which calls the `DeleteInstallation` endpoint.

<img width="861" alt="image" src="https://github.com/amp-labs/cli/assets/11367844/463a3851-c467-47d2-a1fb-b54b6e898627">
<img width="1155" alt="image" src="https://github.com/amp-labs/cli/assets/11367844/c715f1a2-d2a7-4dad-adb8-440945e4450b">
