### PR TITLE
[ENG-869] feat: Revise CLI X-Amp headers

### DIFF
--- a/request/request.go
+++ b/request/request.go
@@ -14,6 +14,8 @@ import (
 	"github.com/amp-labs/cli/utils"
 )
 
+const clientName = "amp-cli"
+
 type RequestClient struct {
 	Client         *http.Client
 	DefaultHeaders []Header
@@ -28,16 +30,26 @@ type Header struct {
 func NewRequestClient() *RequestClient {
 	versionInfo := utils.GetVersionInformation()
 
+	headers := []Header{
+		{Key: "X-Amp-Client", Value: clientName},
+		{Key: "X-Amp-Client-Version", Value: versionInfo.Version},
+		{Key: "X-Amp-Client-Commit", Value: versionInfo.CommitID},
+		{Key: "X-Amp-Client-Branch", Value: versionInfo.Branch},
+		{Key: "X-Amp-Client-Build-Date", Value: versionInfo.BuildDate},
+	}
+
+	if versionInfo.Stage != utils.Prod {
+		// We really only care if these are non-prod clients. Otherwise
+		// it's safe to just assume prod.
+		headers = append(headers, Header{
+			Key:   "X-Amp-Client-Stage",
+			Value: string(versionInfo.Stage),
+		})
+	}
+
 	return &RequestClient{
-		Client: http.DefaultClient,
-		DefaultHeaders: []Header{
-			{Key: "X-Amp-Client-Application", Value: "cli"},
-			{Key: "X-Amp-Client-Version", Value: versionInfo.Version},
-			{Key: "X-Amp-Client-Commit", Value: versionInfo.CommitID},
-			{Key: "X-Amp-Client-Branch", Value: versionInfo.Branch},
-			{Key: "X-Amp-Client-Build-Date", Value: versionInfo.BuildDate},
-			{Key: "X-Amp-Client-Stage", Value: string(versionInfo.Stage)},
-		},
+		Client:         http.DefaultClient,
+		DefaultHeaders: headers,
 	}
 }
 

--- a/request/request.go
+++ b/request/request.go
@@ -31,11 +31,12 @@ func NewRequestClient() *RequestClient {
 	return &RequestClient{
 		Client: http.DefaultClient,
 		DefaultHeaders: []Header{
-			{Key: "X-Cli-Version", Value: versionInfo.Version},
-			{Key: "X-Cli-Commit", Value: versionInfo.CommitID},
-			{Key: "X-Cli-Branch", Value: versionInfo.Branch},
-			{Key: "X-Cli-Build-Date", Value: versionInfo.BuildDate},
-			{Key: "X-Cli-Stage", Value: string(versionInfo.Stage)},
+			{Key: "X-Amp-Client-Application", Value: "cli"},
+			{Key: "X-Amp-Client-Version", Value: versionInfo.Version},
+			{Key: "X-Amp-Client-Commit", Value: versionInfo.CommitID},
+			{Key: "X-Amp-Client-Branch", Value: versionInfo.Branch},
+			{Key: "X-Amp-Client-Build-Date", Value: versionInfo.BuildDate},
+			{Key: "X-Amp-Client-Stage", Value: string(versionInfo.Stage)},
 		},
 	}
 }


### PR DESCRIPTION
Related to [ENG-831](https://linear.app/ampersand/issue/ENG-831/introduce-centralized-useapi-hook-and-always-add-headers-that-self), let's make the headers that the CLI sends consistent with the headers that the UI library sends:

X-Amp-Client-Application : CLI

alternatives: X-Amp-Client-Platform, X-Amp-Client-Flavor, X-Amp-Client-Framework

X-Amp-Client-Version

X-Amp-Client-WhateverElse