### PR TITLE
[ENG-1134] Edit  error message to hint users to --debug when deploy fails

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,3 +67,7 @@ task build
 ```
 
 Now you can run `lamp` commands from anywhere on your computer and it'll use your latest code!
+
+## Trouble shooitng
+
+If you encounter issues with `lamp login` try `lamp logout` and login again. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ### First Time Set Up
 
-1. Download Taskfile by following the instructions at: https://taskfile.dev/installation/
+1. Download Taskfile by following the instructions at: <https://taskfile.dev/installation/>
 
 2. Run the following command from the root of the repo to build the CLI, this will create an executable file called `amp` in the bin folder.
 
@@ -17,15 +17,19 @@ sudo ln -s $PWD/bin/amp /usr/local/bin/lamp
 ```
 
 You can test if this worked by running the following:
+
 ```
 which lamp
 ```
+
 It should print `/usr/local/bin/lamp`
 
 Now you can run the following from anywhere on your computer:
+
 ```
 lamp
 ```
+
 This should print a list of available commands in the CLI.
 
 Now you can run `lamp` commands from anywhere on your computer, and it'll use your local version!
@@ -34,15 +38,15 @@ If this doesn't work, then you'll need to add `/usr/local/bin` to your PATH vari
 
 You should also install the following linting tools by following the linked instructions:
 
-- https://golangci-lint.run/usage/install/#local-installation
-- https://github.com/daixiang0/gci?tab=readme-ov-file#installation
-- https://github.com/bombsimon/wsl?tab=readme-ov-file#installation
+- <https://golangci-lint.run/usage/install/#local-installation>
+- <https://github.com/daixiang0/gci?tab=readme-ov-file#installation>
+- <https://github.com/bombsimon/wsl?tab=readme-ov-file#installation>
 
 These will allow you to run `task lint` (to lint your code) and `task fix` (to fix linting errors automatically).
 
-### Steps for setup on Windows Operating System.
+### Steps for setup on Windows Operating System
 
-1. Download Taskfile by following the instructions at: https://taskfile.dev/installation/.
+1. Download Taskfile by following the instructions at: <https://taskfile.dev/installation/>.
 
 2. Run the following command from the root of the repo to build the CLI, this will create an executable file called `amp` in the bin folder.
     `task build`
@@ -57,7 +61,6 @@ These will allow you to run `task lint` (to lint your code) and `task fix` (to f
 
 5. You can now run the command `lamp` from anywhere in the command line, and it will execute the `amp.exe` file.
 
-
 ### Ongoing Development
 
 Whenever you make code changes, and want to test it locally, run
@@ -70,4 +73,4 @@ Now you can run `lamp` commands from anywhere on your computer and it'll use you
 
 ## Trouble shooitng
 
-If you encounter issues with `lamp login` try `lamp logout` and login again. 
+If you encounter issues with `lamp login` try `lamp logout` and login again.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: fix
+fix:
+	wsl --allow-cuddle-declarations --fix ./... && \
+		gci write . && \
+		markdownlint --fix . && \
+		golangci-lint run -c .golangci.yml --fix
+
+.PHONY: fix/sort
+fix/sort:
+	make fix | grep "" | sort

--- a/cmd/delete_installation.go
+++ b/cmd/delete_installation.go
@@ -11,7 +11,7 @@ var deleteInstallationCmd = &cobra.Command{ //nolint:gochecknoglobals
 	Use:   "delete:installation <integrationId> <installationId>",
 	Short: "Delete installation",
 	Long:  "Delete installation",
-	Args:  cobra.ExactArgs(2), //nolint:gomnd
+	Args:  cobra.ExactArgs(2), //nolint:mnd
 	Run: func(cmd *cobra.Command, args []string) {
 		logger.Debug("Deleting installation")
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -73,7 +73,10 @@ var deployCmd = &cobra.Command{ //nolint:gochecknoglobals
 		integrations, err := client.BatchUpsertIntegrations(cmd.Context(),
 			request.BatchUpsertIntegrationsParams{SourceZipURL: gcsURL})
 		if err != nil {
-			logger.FatalErr("Unable to deploy integrations", err)
+			logger.FatalErr(
+				"Unable to deploy integrations, you can try to run the command again with '--debug' flag to troubleshoot.",
+				err,
+			)
 		}
 
 		names := make([]string, len(integrations))

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -74,7 +74,7 @@ var deployCmd = &cobra.Command{ //nolint:gochecknoglobals
 			request.BatchUpsertIntegrationsParams{SourceZipURL: gcsURL})
 		if err != nil {
 			logger.FatalErr(
-				"Unable to deploy integrations, you can try to run the command again with '--debug' flag to troubleshoot.\n",
+				"Unable to deploy integrations, you can run the command again with '--debug' flag to troubleshoot.\n",
 				err,
 			)
 		}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -74,7 +74,7 @@ var deployCmd = &cobra.Command{ //nolint:gochecknoglobals
 			request.BatchUpsertIntegrationsParams{SourceZipURL: gcsURL})
 		if err != nil {
 			logger.FatalErr(
-				"Unable to deploy integrations, you can try to run the command again with '--debug' flag to troubleshoot.\n\n",
+				"Unable to deploy integrations, you can try to run the command again with '--debug' flag to troubleshoot.\n",
 				err,
 			)
 		}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -74,7 +74,7 @@ var deployCmd = &cobra.Command{ //nolint:gochecknoglobals
 			request.BatchUpsertIntegrationsParams{SourceZipURL: gcsURL})
 		if err != nil {
 			logger.FatalErr(
-				"Unable to deploy integrations, you can try to run the command again with '--debug' flag to troubleshoot.",
+				"Unable to deploy integrations, you can try to run the command again with '--debug' flag to troubleshoot.\n\n",
 				err,
 			)
 		}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -32,7 +32,7 @@ func Fatal(msg string) {
 }
 
 func FatalErr(msg string, err error) {
-	Fatal(fmt.Sprintf("%v, err: %v", msg, err))
+	Fatal(fmt.Sprintf("%v\nerr: %v", msg, err))
 	PrintDebugTip()
 }
 

--- a/storage/upload.go
+++ b/storage/upload.go
@@ -19,6 +19,7 @@ func Upload(ctx context.Context, data []byte, url, md5 string) error {
 	}
 
 	if len(md5) > 0 {
+		//nolint:canonicalheader
 		req.Header.Set("Content-MD5", md5)
 	}
 


### PR DESCRIPTION
Edited error messages to print better hints

```
jaehyunlim@Jaehyuns-MacBook-Pro cli % lamp deploy . --project=f371bbd0-c86a-4a15-9ba8-400b6d67de97
Unable to deploy integrations, you can run the command again with '--debug' flag to troubleshoot.

err: error response from API: HTTP Status 422 Unprocessable Entity
```