### PR TITLE
[ENG-1123] Improved zip logic

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -4,7 +4,6 @@ import (
 	"crypto/md5" //nolint:gosec
 	"encoding/base64"
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/amp-labs/cli/files"
@@ -12,16 +11,15 @@ import (
 	"github.com/amp-labs/cli/logger"
 	"github.com/amp-labs/cli/request"
 	"github.com/amp-labs/cli/storage"
-	"github.com/amp-labs/cli/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
 var deployCmd = &cobra.Command{ //nolint:gochecknoglobals
-	Use:     "deploy <sourceFolderPath>",
+	Use:     "deploy <ampYamlSourcePath>",
 	Aliases: []string{"deploy:integration"},
-	Short:   "Deploy amp.yaml file",
-	Long:    "Deploy changes to amp.yaml file.",
+	Short:   "Deploy changes to integrations",
+	Long:    "Deploy changes to integrations, you can either provide a path to the folder that contains amp.yaml or a path to the file itself",
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		projectId := flags.GetProjectId()
@@ -31,15 +29,7 @@ var deployCmd = &cobra.Command{ //nolint:gochecknoglobals
 
 		apiKey := viper.GetString("key")
 
-		path := args[0]
-		workingDir := utils.GetWorkingDir()
-		if workingDir == "" {
-			logger.Fatal("Unable to get working directory")
-		}
-
-		folderName := filepath.Join(workingDir, path)
-
-		zippedData, err := files.Zip(folderName)
+		zippedData, err := files.Zip(args[0])
 		if err != nil {
 			logger.FatalErr("Unable to zip folder", err)
 		}

--- a/files/zip.go
+++ b/files/zip.go
@@ -3,75 +3,160 @@ package files
 import (
 	"archive/zip"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
 	"path/filepath"
 )
 
-const mode = 420
+var ErrBadManifest = errors.New("invalid manifest")
+
+const (
+	mode        = 0o644
+	yamlName    = "amp.yaml"
+	yamlAltName = "amp.yml"
+)
+
+func chdir(dir string, function func() error) error {
+	origDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("error getting current working directory: %w", err)
+	}
+
+	err = os.Chdir(dir)
+	if err != nil {
+		return fmt.Errorf("error changing directory: %w", err)
+	}
+
+	var errs []error
+
+	err = function()
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	err = os.Chdir(origDir)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("error changing directory: %w", err))
+	}
+
+	if len(errs) == 1 {
+		return errs[0]
+	} else if len(errs) > 1 {
+		return errors.Join(errs...)
+	}
+
+	return nil
+}
+
+func getZipDir(source string) (string, error) {
+	info, err := os.Stat(source)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("%w: source %q does not exist: %w", ErrBadManifest, source, err)
+		} else {
+			return "", fmt.Errorf("%w: stat %q: %w", ErrBadManifest, source, err)
+		}
+	}
+
+	if info == nil {
+		return "", fmt.Errorf("%w: source %q does not exist: %w", ErrBadManifest, source, err)
+	}
+
+	var sourceDir string
+	if info.IsDir() {
+		sourceDir = source
+	} else {
+		name := filepath.Base(source)
+		if name != yamlName && name != yamlAltName {
+			return "", fmt.Errorf("%w: source %q is not a directory nor an %q file",
+				ErrBadManifest, source, yamlName)
+		}
+
+		sourceDir = filepath.Dir(source)
+	}
+
+	return sourceDir, nil
+}
+
+func statYaml() (os.FileInfo, error) {
+	yamlStat, err := os.Stat(yamlName)
+	if err != nil { //nolint:nestif
+		if os.IsNotExist(err) {
+			yamlStat, err = os.Stat(yamlAltName)
+			if err != nil {
+				if os.IsNotExist(err) {
+					return nil, fmt.Errorf("%s does not exist: %w", yamlName, err)
+				} else {
+					return nil, fmt.Errorf("stat %q: %w", yamlAltName, err)
+				}
+			}
+		} else {
+			return nil, fmt.Errorf("stat %q: %w", yamlName, err)
+		}
+	}
+
+	return yamlStat, nil
+}
+
+func importYaml(writer *zip.Writer) error {
+	yamlStat, err := statYaml()
+	if err != nil {
+		return err
+	}
+
+	header, err := zip.FileInfoHeader(yamlStat)
+	if err != nil {
+		return fmt.Errorf("error adding file header while zipping: %w", err)
+	}
+
+	header.Method = zip.Deflate
+	header.SetMode(mode)
+	header.Name = yamlName
+
+	headerWriter, err := writer.CreateHeader(header)
+	if err != nil {
+		return fmt.Errorf("error adding file header while zipping: %w", err)
+	}
+
+	contents, err := os.ReadFile(yamlStat.Name())
+	if err != nil {
+		return fmt.Errorf("error opening %s file while zipping: %w", yamlStat.Name(), err)
+	}
+
+	_, err = io.Copy(headerWriter, bytes.NewReader(contents))
+	if err != nil {
+		return fmt.Errorf("error copying file for zipping: %w", err)
+	}
+
+	return nil
+}
 
 // Zip creates a zip archive of the given directory in-memory.
-func Zip(sourceDir string) ([]byte, error) { // nolint:funlen,cyclop
+func Zip(source string) ([]byte, error) { // nolint:funlen,cyclop
+	sourceDir, err := getZipDir(source)
+	if err != nil {
+		return nil, err
+	}
+
 	var out bytes.Buffer
-	writer := zip.NewWriter(&out)
 
-	err := filepath.WalkDir(sourceDir, func(path string, dir fs.DirEntry, err error) error {
-		if err != nil {
-			return fmt.Errorf("error zipping: %w", err)
+	chdirErr := chdir(sourceDir, func() error {
+		writer := zip.NewWriter(&out)
+
+		if err := importYaml(writer); err != nil {
+			return err
 		}
 
-		info, err := dir.Info()
-		if err != nil {
-			return fmt.Errorf("error getting file info while zipping: %w", err)
-		}
-
-		if info.IsDir() {
-			return nil
-		}
-
-		header, err := zip.FileInfoHeader(info)
-		if err != nil {
-			return fmt.Errorf("error adding file header while zipping: %w", err)
-		}
-
-		header.Method = zip.Deflate
-		header.SetMode(mode)
-
-		header.Name, err = filepath.Rel(sourceDir, path)
-		if err != nil {
-			return fmt.Errorf("error adding file header while zipping: %w", err)
-		}
-
-		headerWriter, err := writer.CreateHeader(header)
-		if err != nil {
-			return fmt.Errorf("error adding file header while zipping: %w", err)
-		}
-
-		file, err := os.Open(path)
-		if err != nil {
-			return fmt.Errorf("error opening file while zipping: %w", err)
-		}
-
-		_, err = io.Copy(headerWriter, file)
-		if err != nil {
-			return fmt.Errorf("error copying file for zipping: %w", err)
-		}
-
-		err = file.Close()
-		if err != nil {
-			return fmt.Errorf("error closing file while zipping: %w", err)
+		if err := writer.Close(); err != nil {
+			return fmt.Errorf("error closing zip writer: %w", err)
 		}
 
 		return nil
 	})
-	if err != nil {
-		return nil, fmt.Errorf("unable to zip directory: %w", err)
-	}
-
-	if err := writer.Close(); err != nil {
-		return nil, fmt.Errorf("error closing zip writer: %w", err)
+	if chdirErr != nil {
+		return nil, chdirErr
 	}
 
 	return out.Bytes(), nil


### PR DESCRIPTION
The old zip logic had a few issues:
* Relative paths were handled poorly
* Additional files were included along with amp.yaml
* The users weren't clear on whether they needed to give a path to the directory or a path to the file

This PR fixes all of these bullet points. Relative paths are now handled properly, by chdir-ing to the root of the path before doing anything. Furthermore, only amp.yaml will be included in the zip file. Finally, the users can provide either a path to a directory or a path to an amp.yaml file -- and the result will be identical.
