### PR TITLE
feat: Add the my-info command

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/amp-labs/cli/logger"
+	"github.com/amp-labs/cli/request"
+	"github.com/amp-labs/cli/vars"
+	//nolint:gosec
+	"github.com/spf13/cobra"
+)
+
+var myInfoCmd = &cobra.Command{ //nolint:gochecknoglobals
+	Use:   "my-info",
+	Short: "Get info about the current user",
+	Long:  "Get info about the current user",
+	Run: func(cmd *cobra.Command, args []string) {
+		rootURL, ok := os.LookupEnv("AMP_API_URL")
+		if !ok {
+			rootURL = vars.ApiURL
+		}
+
+		client := &request.APIClient{
+			Root:          fmt.Sprintf("%s/%s", rootURL, request.API_VERSION),
+			RequestClient: request.NewRequestClient(),
+		}
+
+		info, err := client.GetMyInfo(cmd.Context())
+		if err != nil {
+			logger.FatalErr("Failed to get user info", err)
+		}
+
+		js, err := json.MarshalIndent(info, "", "  ")
+		if err != nil {
+			logger.FatalErr("Failed to marshal user info", err)
+		}
+
+		fmt.Println(string(js))
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(myInfoCmd)
+}

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -8,6 +8,7 @@ import (
 	"github.com/amp-labs/cli/logger"
 	"github.com/amp-labs/cli/request"
 	"github.com/amp-labs/cli/vars"
+
 	//nolint:gosec
 	"github.com/spf13/cobra"
 )

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -8,8 +8,7 @@ import (
 	"github.com/amp-labs/cli/logger"
 	"github.com/amp-labs/cli/request"
 	"github.com/amp-labs/cli/vars"
-	//nolint:gosec
-	"github.com/spf13/cobra"
+	"github.com/spf13/cobra" //nolint:gosec
 )
 
 var myInfoCmd = &cobra.Command{ //nolint:gochecknoglobals

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -8,7 +8,6 @@ import (
 	"github.com/amp-labs/cli/logger"
 	"github.com/amp-labs/cli/request"
 	"github.com/amp-labs/cli/vars"
-
 	//nolint:gosec
 	"github.com/spf13/cobra"
 )

--- a/openapi/manifest.gen.go
+++ b/openapi/manifest.gen.go
@@ -142,6 +142,7 @@ type OptionalFieldsAutoOption string
 func (t HydratedIntegrationField) AsHydratedIntegrationFieldExistent() (HydratedIntegrationFieldExistent, error) {
 	var body HydratedIntegrationFieldExistent
 	err := json.Unmarshal(t.union, &body)
+
 	return body, err
 }
 
@@ -149,6 +150,7 @@ func (t HydratedIntegrationField) AsHydratedIntegrationFieldExistent() (Hydrated
 func (t *HydratedIntegrationField) FromHydratedIntegrationFieldExistent(v HydratedIntegrationFieldExistent) error {
 	b, err := json.Marshal(v)
 	t.union = b
+
 	return err
 }
 
@@ -161,6 +163,7 @@ func (t *HydratedIntegrationField) MergeHydratedIntegrationFieldExistent(v Hydra
 
 	merged, err := runtime.JsonMerge(t.union, b)
 	t.union = merged
+
 	return err
 }
 
@@ -168,6 +171,7 @@ func (t *HydratedIntegrationField) MergeHydratedIntegrationFieldExistent(v Hydra
 func (t HydratedIntegrationField) AsIntegrationFieldMapping() (IntegrationFieldMapping, error) {
 	var body IntegrationFieldMapping
 	err := json.Unmarshal(t.union, &body)
+
 	return body, err
 }
 
@@ -175,6 +179,7 @@ func (t HydratedIntegrationField) AsIntegrationFieldMapping() (IntegrationFieldM
 func (t *HydratedIntegrationField) FromIntegrationFieldMapping(v IntegrationFieldMapping) error {
 	b, err := json.Marshal(v)
 	t.union = b
+
 	return err
 }
 
@@ -187,6 +192,7 @@ func (t *HydratedIntegrationField) MergeIntegrationFieldMapping(v IntegrationFie
 
 	merged, err := runtime.JsonMerge(t.union, b)
 	t.union = merged
+
 	return err
 }
 
@@ -204,6 +210,7 @@ func (t *HydratedIntegrationField) UnmarshalJSON(b []byte) error {
 func (t IntegrationField) AsIntegrationFieldExistent() (IntegrationFieldExistent, error) {
 	var body IntegrationFieldExistent
 	err := json.Unmarshal(t.union, &body)
+
 	return body, err
 }
 
@@ -211,6 +218,7 @@ func (t IntegrationField) AsIntegrationFieldExistent() (IntegrationFieldExistent
 func (t *IntegrationField) FromIntegrationFieldExistent(v IntegrationFieldExistent) error {
 	b, err := json.Marshal(v)
 	t.union = b
+
 	return err
 }
 
@@ -223,6 +231,7 @@ func (t *IntegrationField) MergeIntegrationFieldExistent(v IntegrationFieldExist
 
 	merged, err := runtime.JsonMerge(t.union, b)
 	t.union = merged
+
 	return err
 }
 
@@ -230,6 +239,7 @@ func (t *IntegrationField) MergeIntegrationFieldExistent(v IntegrationFieldExist
 func (t IntegrationField) AsIntegrationFieldMapping() (IntegrationFieldMapping, error) {
 	var body IntegrationFieldMapping
 	err := json.Unmarshal(t.union, &body)
+
 	return body, err
 }
 
@@ -237,6 +247,7 @@ func (t IntegrationField) AsIntegrationFieldMapping() (IntegrationFieldMapping, 
 func (t *IntegrationField) FromIntegrationFieldMapping(v IntegrationFieldMapping) error {
 	b, err := json.Marshal(v)
 	t.union = b
+
 	return err
 }
 
@@ -249,6 +260,7 @@ func (t *IntegrationField) MergeIntegrationFieldMapping(v IntegrationFieldMappin
 
 	merged, err := runtime.JsonMerge(t.union, b)
 	t.union = merged
+
 	return err
 }
 

--- a/request/api.go
+++ b/request/api.go
@@ -101,6 +101,24 @@ func (c *APIClient) GetPreSignedUploadURL(ctx context.Context, md5 string) (Sign
 	return *signed, nil
 }
 
+func (c *APIClient) GetMyInfo(ctx context.Context) (map[string]any, error) {
+	myInfoURL := c.Root + "/my-info"
+
+	auth, err := c.getAuthHeader(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	myInfo := make(map[string]any)
+
+	_, err = c.RequestClient.Get(ctx, myInfoURL, &myInfo, auth) //nolint:bodyclose
+	if err != nil {
+		return nil, err
+	}
+
+	return myInfo, nil
+}
+
 func (c *APIClient) DeleteIntegration(ctx context.Context, integrationId string) error {
 	delURL := fmt.Sprintf("%s/projects/%s/integrations/%s", c.Root, c.ProjectId, integrationId)
 


### PR DESCRIPTION
Sometimes it would be useful to call the my-info endpoint to fetch info about the logged in user. This PR adds a command to make that call and dump the JSON data.

<img width="579" alt="Screenshot 2024-05-21 at 12 57 39 PM" src="https://github.com/amp-labs/cli/assets/470731/0648a138-1770-4661-9b0e-f2207effd5ff">
