### PR TITLE
feat: Add "deploy:destination" command

### DIFF
--- a/cmd/deploy_destination.go
+++ b/cmd/deploy_destination.go
@@ -14,9 +14,10 @@ import (
 )
 
 var deployDestinationCmd = &cobra.Command{ //nolint:gochecknoglobals
-	Use:   "deploy:destination -i <input file path> [-o <output file path>] [-f <format>]",
-	Short: "Deploy a destination",
-	Long:  "Deploy a destination",
+	Use:    "deploy:destination -i <input file path> [-o <output file path>] [-f <format>]",
+	Short:  "Deploy a destination",
+	Long:   "Deploy a destination",
+	Hidden: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		apiKey := flags.GetAPIKey()
 

--- a/cmd/deploy_destination.go
+++ b/cmd/deploy_destination.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"reflect"
+
+	"github.com/amp-labs/cli/flags"
+	"github.com/amp-labs/cli/logger"
+	"github.com/amp-labs/cli/request"
+	"github.com/amp-labs/cli/utils"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var deployDestinationCmd = &cobra.Command{ //nolint:gochecknoglobals
+	Use:   "deploy:destination -i <input file path> [-o <output file path>] [-f <format>]",
+	Short: "Deploy a destination",
+	Long:  "Deploy a destination",
+	Run: func(cmd *cobra.Command, args []string) {
+		apiKey := flags.GetAPIKey()
+
+		projectId := flags.GetProjectId()
+		if projectId == "" {
+			logger.Fatal("Must provide a project ID in the --project flag")
+		}
+
+		input := viper.GetString("input")
+		if input == "" {
+			logger.Fatal("Must provide an input file path")
+		}
+
+		var dest request.Destination
+		if _, err := utils.ReadStructFromFile(input, &dest); err != nil {
+			logger.FatalErr("Unable to read destination file", err)
+		}
+
+		client := request.NewAPIClient(projectId, &apiKey)
+		oldDest := getOldDest(cmd.Context(), client, &dest)
+
+		var output *request.Destination
+		var err error
+
+		if oldDest == nil {
+			output, err = client.CreateDestination(cmd.Context(), &dest)
+		} else {
+			patch := generatePatch(oldDest, &dest)
+			if len(patch.UpdateMask) == 0 {
+				if err := utils.WriteStructToFile(viper.GetString("output"),
+					flags.GetOutputFormat(), oldDest); err != nil {
+					logger.FatalErr("Unable to write destination file", err)
+				}
+
+				return
+			}
+
+			output, err = client.PatchDestination(cmd.Context(), oldDest.Id, patch)
+		}
+
+		if err != nil {
+			logger.FatalErr("Unable to deploy destination", err)
+		}
+
+		if err := utils.WriteStructToFile(viper.GetString("output"),
+			flags.GetOutputFormat(), output); err != nil {
+			logger.FatalErr("Unable to write destination file", err)
+		}
+	},
+}
+
+func generatePatch(oldDest *request.Destination, newDest *request.Destination) *request.PatchDestination {
+	patch := &request.PatchDestination{
+		Destination: make(map[string]any),
+	}
+
+	if oldDest.Name != newDest.Name {
+		patch.Destination["name"] = newDest.Name
+		patch.UpdateMask = append(patch.UpdateMask, "name")
+	}
+
+	if oldDest.Type != newDest.Type {
+		patch.Destination["type"] = newDest.Type
+		patch.UpdateMask = append(patch.UpdateMask, "type")
+	}
+
+	if oldDest.Metadata != nil { //nolint:nestif
+		if newDest.Metadata == nil {
+			patch.Destination["metadata"] = nil
+			patch.UpdateMask = append(patch.UpdateMask, "metadata")
+		} else if !reflect.DeepEqual(oldDest.Metadata, newDest.Metadata) {
+			patch.Destination["metadata"] = newDest.Metadata
+			patch.UpdateMask = append(patch.UpdateMask, "metadata")
+		}
+	} else {
+		if newDest.Metadata != nil {
+			patch.Destination["metadata"] = newDest.Metadata
+			patch.UpdateMask = append(patch.UpdateMask, "metadata")
+		}
+	}
+
+	return patch
+}
+
+func getOldDest(ctx context.Context, client *request.APIClient, dest *request.Destination) *request.Destination {
+	id := findDestId(ctx, client, dest)
+	if id == "" {
+		return nil
+	}
+
+	dst, err := client.GetDestination(ctx, id)
+	if err != nil {
+		if errors.Is(err, request.ErrNotFound) {
+			return nil
+		} else {
+			logger.FatalErr("Unable to get destination", err)
+		}
+	}
+
+	return dst
+}
+
+func findDestId(ctx context.Context, client *request.APIClient, dest *request.Destination) string {
+	if dest.Id != "" {
+		return dest.Id
+	}
+
+	dests, err := client.ListDestinations(ctx)
+	if err != nil {
+		logger.FatalErr("Unable to list destinations", err)
+	}
+
+	for _, d := range dests {
+		if d.Name == dest.Name {
+			return d.Id
+		}
+	}
+
+	return ""
+}
+
+func init() {
+	deployDestinationCmd.Flags().StringP("input", "i", "", "The input file path")
+
+	if err := viper.BindPFlag("input", deployDestinationCmd.Flags().Lookup("input")); err != nil {
+		logger.FatalErr("unable to bind flag", err)
+	}
+
+	deployDestinationCmd.Flags().StringP("output", "o", "-", "The output file path")
+
+	if err := viper.BindPFlag("output", deployDestinationCmd.Flags().Lookup("output")); err != nil {
+		logger.FatalErr("unable to bind flag", err)
+	}
+
+	rootCmd.AddCommand(deployDestinationCmd)
+}

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -1,16 +1,17 @@
 package cmd
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 
+	"github.com/spf13/cobra" //nolint:gosec
 	"github.com/amp-labs/cli/clerk"
+	"github.com/amp-labs/cli/flags"
 	"github.com/amp-labs/cli/logger"
 	"github.com/amp-labs/cli/request"
+	"github.com/amp-labs/cli/utils"
 	"github.com/amp-labs/cli/vars"
-	"github.com/spf13/cobra" //nolint:gosec
 )
 
 var myInfoCmd = &cobra.Command{ //nolint:gochecknoglobals
@@ -37,12 +38,10 @@ var myInfoCmd = &cobra.Command{ //nolint:gochecknoglobals
 			}
 		}
 
-		js, err := json.MarshalIndent(info, "", "  ")
-		if err != nil {
-			logger.FatalErr("Failed to marshal user info", err)
+		format := flags.GetOutputFormat()
+		if err := utils.WriteStruct(os.Stdout, format, info); err != nil {
+			logger.FatalErr("Unable to write user info", err)
 		}
-
-		fmt.Println(string(js))
 	},
 }
 

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra" //nolint:gosec
 	"github.com/amp-labs/cli/clerk"
 	"github.com/amp-labs/cli/flags"
 	"github.com/amp-labs/cli/logger"
 	"github.com/amp-labs/cli/request"
 	"github.com/amp-labs/cli/utils"
 	"github.com/amp-labs/cli/vars"
+	"github.com/spf13/cobra" //nolint:gosec
 )
 
 var myInfoCmd = &cobra.Command{ //nolint:gochecknoglobals

--- a/cmd/list_destinations.go
+++ b/cmd/list_destinations.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"sort"
+
+	"github.com/amp-labs/cli/clerk"
+	"github.com/amp-labs/cli/flags"
+	"github.com/amp-labs/cli/logger"
+	"github.com/amp-labs/cli/request"
+	"github.com/spf13/cobra"
+)
+
+var listDestinationsCmd = &cobra.Command{ //nolint:gochecknoglobals
+	Use:   "list:destinations",
+	Short: "List destinations",
+	Long:  "List destinations",
+	Run: func(cmd *cobra.Command, args []string) {
+		apiKey := flags.GetAPIKey()
+
+		projectId := flags.GetProjectId()
+		if projectId == "" {
+			logger.Fatal("Must provide a project ID in the --project flag")
+		}
+
+		client := request.NewAPIClient(projectId, &apiKey)
+
+		destinations, err := client.ListDestinations(cmd.Context())
+		if err != nil {
+			if errors.Is(err, clerk.ErrNoSessions) {
+				logger.FatalErr("Authenticated session has expired, please log in using amp login", err)
+			} else {
+				logger.FatalErr("Unable to list destinations", err)
+			}
+		}
+
+		sort.Slice(destinations, func(i, j int) bool {
+			return destinations[i].Name < destinations[j].Name
+		})
+
+		for _, dest := range destinations {
+			logger.Info(dest.Id + " " + dest.Name + " (" + dest.Type + ")")
+			if dest.Metadata != nil {
+				bts, err := json.MarshalIndent(dest.Metadata, "  ", "  ")
+				if err != nil {
+					logger.FatalErr("Failed to marshal destination metadata", err)
+				}
+
+				logger.Info("  " + string(bts))
+			}
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(listDestinationsCmd)
+}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -30,7 +30,7 @@ const WaitBeforeExitSeconds = 3
 func (h *handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	// This path is followed after the user logs in. The CLI Auth Client redirects to here.
 	switch {
-	case request.URL.Path == "/done" && request.Method == "GET":
+	case request.URL.Path == "/done" && request.Method == http.MethodGet:
 		bts, _ := base64.StdEncoding.DecodeString(request.URL.Query().Get("p"))
 
 		rsp, loginEmail, err := processLogin(request.Context(), bts, true)
@@ -54,7 +54,7 @@ func (h *handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 		}()
 
 		return
-	case request.URL.Path == "/" && request.Method == "GET":
+	case request.URL.Path == "/" && request.Method == http.MethodGet:
 		loginURL, ok := os.LookupEnv("AMP_LOGIN_URL_OVERRIDE")
 		if ok {
 			writer.Header().Set("Location", loginURL)

--- a/flags/config.go
+++ b/flags/config.go
@@ -1,6 +1,9 @@
 package flags
 
 import (
+	"strings"
+
+	"github.com/amp-labs/cli/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -13,6 +16,7 @@ func Init(rootCmd *cobra.Command) error {
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Enable debug logging mode")
 	rootCmd.PersistentFlags().StringP("project", "p", "", "Ampersand project ID")
 	rootCmd.PersistentFlags().StringP("key", "k", "", "Ampersand API key")
+	rootCmd.PersistentFlags().StringP("format", "f", "json", "Output format")
 
 	if err := viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug")); err != nil {
 		return err
@@ -30,7 +34,22 @@ func Init(rootCmd *cobra.Command) error {
 		panic(err)
 	}
 
+	if err := viper.BindPFlag("format", rootCmd.PersistentFlags().Lookup("format")); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+func GetOutputFormat() utils.Format {
+	switch strings.ToLower(viper.GetString("format")) {
+	case "json":
+		return utils.JSON
+	case "yaml", "yml":
+		return utils.YAML
+	default:
+		return utils.Unknown
+	}
 }
 
 func GetDebugMode() bool {

--- a/request/api.go
+++ b/request/api.go
@@ -208,6 +208,60 @@ func (c *APIClient) ListDestinations(ctx context.Context) ([]*Destination, error
 	return destinations, nil
 }
 
+func (c *APIClient) CreateDestination(ctx context.Context, dest *Destination) (*Destination, error) {
+	createURL := fmt.Sprintf("%s/projects/%s/destinations", c.Root, c.ProjectId)
+
+	auth, err := c.getAuthHeader(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var out Destination
+
+	_, err = c.Client.Post(ctx, createURL, dest, &out, auth) //nolint:bodyclose
+	if err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+func (c *APIClient) GetDestination(ctx context.Context, id string) (*Destination, error) {
+	getURL := fmt.Sprintf("%s/projects/%s/destinations/%s", c.Root, c.ProjectId, id)
+
+	auth, err := c.getAuthHeader(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var out Destination
+
+	_, err = c.Client.Get(ctx, getURL, &out, auth) //nolint:bodyclose
+	if err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+func (c *APIClient) PatchDestination(ctx context.Context, id string, patch *PatchDestination) (*Destination, error) {
+	patchURL := fmt.Sprintf("%s/projects/%s/destinations/%s", c.Root, c.ProjectId, id)
+
+	auth, err := c.getAuthHeader(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var out Destination
+
+	_, err = c.Client.Patch(ctx, patchURL, patch, &out, auth) //nolint:bodyclose
+	if err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
 func (c *APIClient) DeleteInstallation(ctx context.Context, integrationId string, installationId string) error {
 	delURL := fmt.Sprintf(
 		"%s/projects/%s/integrations/%s/installations/%s", c.Root, c.ProjectId, integrationId, installationId,

--- a/request/api.go
+++ b/request/api.go
@@ -190,6 +190,24 @@ func (c *APIClient) ListProjects(ctx context.Context) ([]*Project, error) {
 	return projects, nil
 }
 
+func (c *APIClient) ListDestinations(ctx context.Context) ([]*Destination, error) {
+	listURL := fmt.Sprintf("%s/projects/%s/destinations", c.Root, c.ProjectId)
+
+	auth, err := c.getAuthHeader(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var destinations []*Destination
+
+	_, err = c.Client.Get(ctx, listURL, &destinations, auth) //nolint:bodyclose
+	if err != nil {
+		return nil, err
+	}
+
+	return destinations, nil
+}
+
 func (c *APIClient) DeleteInstallation(ctx context.Context, integrationId string, installationId string) error {
 	delURL := fmt.Sprintf(
 		"%s/projects/%s/integrations/%s/installations/%s", c.Root, c.ProjectId, integrationId, installationId,

--- a/request/types.go
+++ b/request/types.go
@@ -97,3 +97,20 @@ type Project struct {
 	CreateTime time.Time `json:"createTime"`
 	OrgId      string    `json:"orgId"`
 }
+
+type Destination struct {
+	Id         string           `json:"id"`
+	ProjectId  string           `json:"projectId"`
+	Name       string           `json:"name"`
+	Type       string           `json:"type"`
+	Metadata   *WebhookMetadata `json:"metadata"`
+	CreateTime time.Time        `json:"createTime"`
+	UpdateTime time.Time        `json:"updateTime"`
+}
+
+type WebhookMetadata struct {
+	URL            string            `json:"url"`
+	Headers        map[string]string `json:"headers,omitempty"`
+	SvixAppId      string            `json:"svixAppId,omitempty"`
+	SvixEndpointId string            `json:"svixEndpointId,omitempty"`
+}

--- a/request/types.go
+++ b/request/types.go
@@ -108,6 +108,11 @@ type Destination struct {
 	UpdateTime time.Time        `json:"updateTime"`
 }
 
+type PatchDestination struct {
+	Destination map[string]any `json:"destination"`
+	UpdateMask  []string       `json:"updateMask"`
+}
+
 type WebhookMetadata struct {
 	URL            string            `json:"url"`
 	Headers        map[string]string `json:"headers,omitempty"`

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,18 +1,121 @@
 package utils
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
 	"os"
 
-	"github.com/amp-labs/cli/logger"
+	"sigs.k8s.io/yaml"
+)
+
+type Format string
+
+const (
+	Unknown Format = ""
+	JSON    Format = "json"
+	YAML    Format = "yaml"
+)
+
+var (
+	ErrReadFile      = errors.New("unable to read file")
+	ErrUnknownFormat = errors.New("unknown format")
 )
 
 func GetWorkingDir() string {
 	workingDir, err := os.Getwd()
 	if err != nil {
-		logger.FatalErr("Unable to get working directory", err)
-
 		return ""
 	}
 
 	return workingDir
+}
+
+func ReadStruct(r io.Reader, out any) (Format, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return Unknown, err
+	}
+
+	if err := json.Unmarshal(data, out); err != nil {
+		var se *json.SyntaxError
+		if !errors.As(err, &se) {
+			return Unknown, err
+		}
+	} else {
+		return JSON, nil
+	}
+
+	if err := yaml.Unmarshal(data, out); err != nil {
+		return Unknown, err
+	}
+
+	return YAML, nil
+}
+
+func ReadStructFromFile(filePath string, out any) (Format, error) {
+	if filePath == "-" {
+		return ReadStruct(os.Stdin, out)
+	}
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		return Unknown, err
+	}
+
+	defer func() {
+		_ = f.Close()
+	}()
+
+	if format, err := ReadStruct(f, out); err == nil {
+		return format, nil
+	}
+
+	return Unknown,
+		fmt.Errorf("%w: failed to unmarshal %s (not valid JSON or YAML)",
+			ErrReadFile, filePath)
+}
+
+func WriteStruct(writer io.Writer, format Format, data any) error {
+	switch format { //nolint:exhaustive
+	case JSON:
+		enc := json.NewEncoder(writer)
+		enc.SetIndent("", "  ")
+		enc.SetEscapeHTML(false)
+
+		if err := enc.Encode(data); err != nil {
+			return err
+		}
+
+		return nil
+	case YAML:
+		bts, err := yaml.Marshal(data)
+		if err != nil {
+			return err
+		}
+
+		_, err = writer.Write(bts)
+
+		return err
+	default:
+		return ErrUnknownFormat
+	}
+}
+
+func WriteStructToFile(filePath string, format Format, data any) error {
+	if filePath == "-" {
+		return WriteStruct(os.Stdout, format, data)
+	}
+
+	f, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = f.Close()
+	}()
+
+	return WriteStruct(f, format, data)
 }


### PR DESCRIPTION
This lets us be more declarative about destinations (define in yaml, similar to amp.yaml) - and not be 100% reliant on the console.

<img width="649" alt="Screenshot 2024-06-19 at 4 04 59 PM" src="https://github.com/amp-labs/cli/assets/470731/71bb1b25-9b35-4368-a798-b0c8eef5b57b">

<img width="1273" alt="Screenshot 2024-06-19 at 4 03 50 PM" src="https://github.com/amp-labs/cli/assets/470731/ebf6dee0-5e0d-444f-8bc2-6ad7bc9bd743">

This also refactors some of the code so that structured output (JSON, YAML) can be handled in a more generic manner.