### PR TITLE
fix: Update goreleaser format

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,5 @@
 # Documentation at https://goreleaser.com
+version: 2
 before:
   hooks:
     - go mod tidy
@@ -52,7 +53,7 @@ brews:
   - repository:
       owner: amp-labs
       name: homebrew-cli
-    folder: Formula
+    directory: Formula
     description: The Ampersand CLI
 
 nfpms:


### PR DESCRIPTION
goreleaser just had a major new version (version 2). This breaks the yaml slightly, a version number is now required, and one of the field names changed.
