### PR TITLE
feat: Add the list:provider-apps command

### DIFF
--- a/cmd/list_provider_apps.go
+++ b/cmd/list_provider_apps.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"errors"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/amp-labs/cli/clerk"
+	"github.com/amp-labs/cli/flags"
+	"github.com/amp-labs/cli/logger"
+	"github.com/amp-labs/cli/request"
+	"github.com/buildkite/shellwords"
+	"github.com/spf13/cobra"
+)
+
+func quote(s string) string {
+	return "\"" + strings.Trim(shellwords.Quote(s), "\"") + "\""
+}
+
+var listProviderAppsCmd = &cobra.Command{ //nolint:gochecknoglobals
+	Use:    "list:provider-apps",
+	Short:  "List provider apps",
+	Long:   "List provider apps",
+	Hidden: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		projectId := flags.GetProjectId()
+		if projectId == "" {
+			logger.Fatal("Must provide a project ID in the --project flag")
+		}
+
+		apiKey := flags.GetAPIKey()
+
+		client := request.NewAPIClient(projectId, &apiKey)
+
+		apps, err := client.ListProviderApps(cmd.Context())
+		if err != nil {
+			if errors.Is(err, clerk.ErrNoSessions) {
+				logger.FatalErr("Authenticated session has expired, please log in using amp login", err)
+			} else {
+				logger.FatalErr("Unable to list connections", err)
+			}
+		}
+
+		sort.Slice(apps, func(i, j int) bool {
+			return apps[i].CreateTime.Before(apps[j].CreateTime)
+		})
+
+		for _, app := range apps {
+			parts := []string{
+				app.Id,
+				app.CreateTime.Format(time.RFC3339),
+				app.Provider,
+			}
+
+			if len(app.ClientId) > 0 {
+				parts = append(parts, "clientId="+quote(app.ClientId))
+			}
+
+			if len(app.ClientSecret) > 0 {
+				secret := strings.Map(func(_ rune) rune {
+					return '*'
+				}, app.ClientSecret)
+
+				parts = append(parts, "clientSecret="+quote(secret))
+			}
+
+			if app.ExternalRef != "" {
+				parts = append(parts, "externalRef="+quote(app.ExternalRef))
+			}
+
+			if len(app.Scopes) > 0 {
+				for i, scope := range app.Scopes {
+					app.Scopes[i] = quote(scope)
+				}
+
+				parts = append(parts, "scopes=["+strings.Join(app.Scopes, ", ")+"]")
+			}
+
+			logger.Info(strings.Join(parts, " "))
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(listProviderAppsCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 
 require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
+	github.com/buildkite/shellwords v0.0.0-20180315110454-59467a9b8e10 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7D
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/brianvoe/gofakeit/v6 v6.19.0/go.mod h1:Ow6qC71xtwm79anlwKRlWZW6zVq9D2XHE4QSSMP/rU8=
+github.com/buildkite/shellwords v0.0.0-20180315110454-59467a9b8e10 h1:XwHQ5xDtYPdtBbVPyRO6UZoWZe8/mbKUb076f8x7RvI=
+github.com/buildkite/shellwords v0.0.0-20180315110454-59467a9b8e10/go.mod h1:gv0DYOzHEsKgo31lTCDGauIg4DTTGn41Bzp+t3wSOlk=
 github.com/clerkinc/clerk-sdk-go v1.49.0 h1:tJLIAx3qfP2cNQJ/iPq6OF1BSB0NzI3alcOuEueexoA=
 github.com/clerkinc/clerk-sdk-go v1.49.0/go.mod h1:pejhMTTDAuw5aBpiHBEOOOHMAsxNfPvKfM5qexFJYlc=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=

--- a/request/api.go
+++ b/request/api.go
@@ -190,6 +190,24 @@ func (c *APIClient) ListConnections(ctx context.Context) ([]*Connection, error) 
 	return connections, nil
 }
 
+func (c *APIClient) ListProviderApps(ctx context.Context) ([]*ProviderApp, error) {
+	listURL := fmt.Sprintf("%s/projects/%s/provider-apps", c.Root, c.ProjectId)
+
+	auth, err := c.getAuthHeader(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var providerApps []*ProviderApp
+
+	_, err = c.Client.Get(ctx, listURL, &providerApps, auth) //nolint:bodyclose
+	if err != nil {
+		return nil, err
+	}
+
+	return providerApps, nil
+}
+
 func (c *APIClient) ListProjects(ctx context.Context) ([]*Project, error) {
 	listURL := c.Root + "/projects"
 


### PR DESCRIPTION
This PR adds a command to list the provider apps. Marked as hidden for now.

```
$> ./bin/amp list:provider-apps --project 9482e676-4874-43a4-beea-fa8081d13a07
196412b0-b3b7-434a-be1a-2910964d05a3 2024-01-04T22:22:39Z salesforce clientId="3MVG9kBt168mda__AsLfwj2vUtrPMp39Nvj9amL1F7wMQhoDK7FgznCLTvYMIYLcDidAVGom5YCeiVbbFkE3X" externalRef="externalRef:p3:e3:pr0"
4127ae9d-b694-4c19-b80f-8648d59b3b13 2024-02-20T19:37:36Z linkedin clientId="test-client-id" scopes=["no-scope"]
cd72cfb7-5625-45c9-808f-79924160c161 2024-04-05T18:08:27Z notion clientId="test"
be6ed573-016c-44db-be56-6ac05007933b 2024-04-16T23:17:13Z hubspot clientId="f49c98fd-02ce-4fea-bf88-a2425a2897d5" externalRef="externalRef:p3:e3:pr0" scopes=["oauth", "tickets", "crm.objects.contacts.read", "crm.objects.companies.read", "crm.objects.deals.read", "crm.objects.line_items.read"]
87d7f2fe-2628-46fc-8f12-5e8f7534c49b 2024-04-24T22:00:21Z webflow clientId="aa9c1f0ff0b9c7c5f68173e334be0bf62c6575f42f60384be3474a4f6df96ded" externalRef="externalRef:p3:e3:pr0" scopes=["cms:read", "cms:write", "sites:read"]
030a7aec-5e2f-4d15-90a5-3e6a857abfa5 2024-06-06T15:02:18Z mock clientId="test" externalRef="mock"
```