### PR TITLE
feat: add success login page html

### DIFF
--- a/clerk/successLogin.html
+++ b/clerk/successLogin.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>login success</title>
+    <style>
+        body {
+            display: flex;
+            flex-direction: column;
+            height: 100vh;
+            margin: 0;
+            padding: 0;
+            font-family: Display, sans-serif;    
+        }
+        .navbar {
+            display: flex;
+            justify-content: flex-start;
+            align-items: center;
+            padding: 1rem 2rem;
+            height: 2rem;
+            background-color: #f2f2f2;
+        }
+        .logo {
+            font-size: 1.5rem;
+            font-weight: 600;
+        }
+        .content {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            flex-direction: column;
+            height: calc(100vh - 2rem);
+            width: 100%;
+        }
+        .content-center {
+           text-align: center;
+           line-height: .8rem;
+        }
+        .line1 {
+            font-weight: 300;
+            font-size: 2rem;
+        }
+        .line2 {
+            font-size: 2rem;
+            font-weight: 700;
+            color: #4F1EB8;
+        }
+        .line3 {
+            font-weight: 300;
+            font-size: 1rem;
+            margin-bottom: 2rem;
+        }
+        .minimal-button {
+            background-color: transparent;
+            color: black;
+            border: none;
+            padding: 0.5rem 1rem;
+            border-radius: 0.5rem;
+            font-size: 1rem;
+            cursor: pointer;
+            transition: all ease .3s;
+            border: 1px solid black;
+            text-decoration: none;
+        }
+        .minimal-button:hover {
+            background-color: #6F3ED8;
+            color: white;
+        }
+    </style>
+</head>
+<body>
+    <div class="navbar">
+        <span class="logo">Ampersand</span>
+    </div>
+    <div class="content">
+        <div class="content-center">
+            <h2 class="line1">Successfully logged in as</h2>
+            <p class="line2">{{email}}</p>
+            <p class="line3">You can close this tab and return to the CLI.</p>
+            <a class="minimal-button" href="https://docs.withampersand.com/docs/quickstart" target="_blank">Read docs</a>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
### Summary
When the user logs in and is redirected from the CLI. There is a confirmation page. 

#### Before 
<img width="521" alt="Screenshot 2024-07-31 at 3 51 27 PM" src="https://github.com/user-attachments/assets/0dc57fbf-12cc-4480-a35b-a3994d89cc35">

#### After
##### full page
<img width="1270" alt="Screenshot 2024-07-31 at 3 43 25 PM" src="https://github.com/user-attachments/assets/051869f8-d0a8-41bf-8b2f-dc9683b1ede7">

##### hover state
<img width="466" alt="Screenshot 2024-07-31 at 3 43 32 PM" src="https://github.com/user-attachments/assets/39a1ae4a-2cca-4b38-8391-b3d911693965">

##### flexible layout
<img width="512" alt="Screenshot 2024-07-31 at 3 50 06 PM" src="https://github.com/user-attachments/assets/ac77d962-a7fb-47df-8b4c-2447db7e8be1">
