### PR TITLE
feat: Allow the stage to be overridden at runtime

### DIFF
--- a/clerk/clerk.go
+++ b/clerk/clerk.go
@@ -17,6 +17,7 @@ import (
 	"github.com/adrg/xdg"
 	"github.com/alexkappa/mustache"
 	"github.com/amp-labs/cli/logger"
+	"github.com/amp-labs/cli/utils"
 	"github.com/amp-labs/cli/vars"
 	"github.com/clerkinc/clerk-sdk-go/clerk"
 )
@@ -95,7 +96,7 @@ func GetClerkRootURL() string {
 }
 
 func GetSessionURL(data *LoginData) string {
-	if vars.Stage == "prod" {
+	if utils.GetStage() == "prod" {
 		return fmt.Sprintf(ClientSessionPathProd, GetClerkRootURL())
 	}
 
@@ -103,11 +104,13 @@ func GetSessionURL(data *LoginData) string {
 }
 
 func GetJwtFile() string {
-	if vars.Stage == "prod" {
+	stage := utils.GetStage()
+
+	if stage == "prod" {
 		return "amp/jwt.json"
 	}
 
-	return fmt.Sprintf("amp/jwt-%s.json", vars.Stage)
+	return fmt.Sprintf("amp/jwt-%s.json", stage)
 }
 
 // GetJwtPath returns the path to the jwt.json file where the JWT token is stored.

--- a/request/request.go
+++ b/request/request.go
@@ -14,7 +14,6 @@ import (
 	"github.com/amp-labs/cli/flags"
 	"github.com/amp-labs/cli/logger"
 	"github.com/amp-labs/cli/utils"
-	"github.com/amp-labs/cli/vars"
 )
 
 const clientName = "amp-cli"
@@ -242,7 +241,7 @@ func (c *Client) makeRequestAndParseJSONResult(req *http.Request, result any) (*
 }
 
 func addDebugHeader(req *http.Request) {
-	if vars.Stage != "prod" {
+	if utils.GetStage() != "prod" {
 		if flags.GetDebugMode() {
 			req.Header.Add("X-Amp-Debug-Mode", "true")
 		}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/amp-labs/cli/vars"
 	"sigs.k8s.io/yaml"
 )
 
@@ -101,6 +102,15 @@ func WriteStruct(writer io.Writer, format Format, data any) error {
 	default:
 		return ErrUnknownFormat
 	}
+}
+
+func GetStage() string {
+	stage, ok := os.LookupEnv("AMP_STAGE_OVERRIDE")
+	if ok {
+		return stage
+	}
+
+	return vars.Stage
 }
 
 func WriteStructToFile(filePath string, format Format, data any) error {


### PR DESCRIPTION
Right now most runtime vars can be overridden (api endpoint, clerk login endpoint, etc). This lets us use prod binaries against dev and staging, which is useful.

However stage is hard-coded. This makes the program slightly clunky because the local paths it uses to store credentials are mis-matched. This can be worked around, but it's just kind of confusing.

This allows the caller to override the effective stage by setting `AMP_STAGE_OVERRIDE`, which will eliminate the mismatched credentials confusion.
