### PR TITLE
[auto] Update openapi dependency

### DIFF
--- a/openapi/manifest.gen.go
+++ b/openapi/manifest.gen.go
@@ -17,12 +17,7 @@ const (
 
 // Defines values for OptionalFieldsAutoOption.
 const (
-	OptionalFieldsAutoOptionAll OptionalFieldsAutoOption = "all"
-)
-
-// Defines values for SelectedFieldsAutoOption.
-const (
-	SelectedFieldsAutoOptionAll SelectedFieldsAutoOption = "all"
+	All OptionalFieldsAutoOption = "all"
 )
 
 // Backfill defines model for Backfill.
@@ -145,7 +140,6 @@ type IntegrationObject struct {
 	OptionalFieldsAuto *OptionalFieldsAutoOption `json:"optionalFieldsAuto,omitempty"`
 	RequiredFields     *[]IntegrationField       `json:"requiredFields,omitempty"`
 	Schedule           string                    `json:"schedule"`
-	SelectedFieldsAuto *SelectedFieldsAutoOption `json:"selectedFieldsAuto,omitempty"`
 }
 
 // IntegrationProxy defines model for IntegrationProxy.
@@ -178,9 +172,6 @@ type Manifest struct {
 
 // OptionalFieldsAutoOption defines model for OptionalFieldsAutoOption.
 type OptionalFieldsAutoOption string
-
-// SelectedFieldsAutoOption defines model for SelectedFieldsAutoOption.
-type SelectedFieldsAutoOption string
 
 // AsHydratedIntegrationFieldExistent returns the union data inside the HydratedIntegrationField as a HydratedIntegrationFieldExistent
 func (t HydratedIntegrationField) AsHydratedIntegrationFieldExistent() (HydratedIntegrationFieldExistent, error) {


### PR DESCRIPTION
This updates the dependency to version [8c29d508c34c7b621231166904442bfdecc9c189](https://github.com/amp-labs/openapi/commit/8c29d508c34c7b621231166904442bfdecc9c189) from [main](https://github.com/amp-labs/openapi/tree/main)