### PR TITLE
[auto] Update openapi dependency

### DIFF
--- a/openapi/manifest.gen.go
+++ b/openapi/manifest.gen.go
@@ -33,9 +33,24 @@ const (
 	All OptionalFieldsAutoOption = "all"
 )
 
+// AssociationChangeEvent defines model for AssociationChangeEvent.
+type AssociationChangeEvent struct {
+	// Enabled If true, the integration will subscribe to association change events.
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// IncludeFullRecords If true, the integration will include full records in the event payload.
+	IncludeFullRecords *bool `json:"includeFullRecords,omitempty"`
+}
+
 // Backfill defines model for Backfill.
 type Backfill struct {
 	DefaultPeriod DefaultPeriod `json:"defaultPeriod"`
+}
+
+// CreateEvent defines model for CreateEvent.
+type CreateEvent struct {
+	// Enabled If true, the integration will subscribe to create events.
+	Enabled *bool `json:"enabled,omitempty"`
 }
 
 // DefaultPeriod defines model for DefaultPeriod.
@@ -45,6 +60,12 @@ type DefaultPeriod struct {
 
 	// FullHistory If true, backfill all history. Required if days is not set.
 	FullHistory *bool `json:"fullHistory,omitempty" validate:"required_without=Days"`
+}
+
+// DeleteEvent defines model for DeleteEvent.
+type DeleteEvent struct {
+	// Enabled If true, the integration will subscribe to delete events.
+	Enabled *bool `json:"enabled,omitempty"`
 }
 
 // Delivery defines model for Delivery.
@@ -168,12 +189,13 @@ type HydratedIntegrationWriteObject struct {
 
 // Integration defines model for Integration.
 type Integration struct {
-	DisplayName *string           `json:"displayName,omitempty"`
-	Name        string            `json:"name"`
-	Provider    string            `json:"provider"`
-	Proxy       *IntegrationProxy `json:"proxy,omitempty"`
-	Read        *IntegrationRead  `json:"read,omitempty"`
-	Write       *IntegrationWrite `json:"write,omitempty"`
+	DisplayName *string               `json:"displayName,omitempty"`
+	Name        string                `json:"name"`
+	Provider    string                `json:"provider"`
+	Proxy       *IntegrationProxy     `json:"proxy,omitempty"`
+	Read        *IntegrationRead      `json:"read,omitempty"`
+	Subscribe   *IntegrationSubscribe `json:"subscribe,omitempty"`
+	Write       *IntegrationWrite     `json:"write,omitempty"`
 }
 
 // IntegrationField defines model for IntegrationField.
@@ -228,6 +250,25 @@ type IntegrationRead struct {
 	Objects *[]IntegrationObject `json:"objects,omitempty"`
 }
 
+// IntegrationSubscribe defines model for IntegrationSubscribe.
+type IntegrationSubscribe struct {
+	Objects *[]IntegrationSubscribeObject `json:"objects,omitempty"`
+}
+
+// IntegrationSubscribeObject defines model for IntegrationSubscribeObject.
+type IntegrationSubscribeObject struct {
+	AssociationChangeEvent *AssociationChangeEvent `json:"AssociationChangeEvent,omitempty"`
+	CreateEvent            *CreateEvent            `json:"CreateEvent,omitempty"`
+	DeleteEvent            *DeleteEvent            `json:"DeleteEvent,omitempty"`
+	OtherEvents            *OtherEvents            `json:"OtherEvents,omitempty"`
+	UpdateEvent            *UpdateEvent            `json:"UpdateEvent,omitempty"`
+	Destination            string                  `json:"destination"`
+
+	// InheritFields If true, the subscribe object will inherit the fields from the read object.
+	InheritFields *bool  `json:"inheritFields,omitempty"`
+	ObjectName    string `json:"objectName"`
+}
+
 // IntegrationWrite defines model for IntegrationWrite.
 type IntegrationWrite struct {
 	Objects *[]IntegrationWriteObject `json:"objects,omitempty"`
@@ -253,6 +294,16 @@ type Manifest struct {
 
 // OptionalFieldsAutoOption defines model for OptionalFieldsAutoOption.
 type OptionalFieldsAutoOption string
+
+// OtherEvents defines model for OtherEvents.
+type OtherEvents = []string
+
+// UpdateEvent defines model for UpdateEvent.
+type UpdateEvent struct {
+	// Enabled If true, the integration will subscribe to update events.
+	Enabled             *bool     `json:"enabled,omitempty"`
+	RequiredWatchFields *[]string `json:"requiredWatchFields,omitempty"`
+}
 
 // ValueDefaults Configuration to set default write values for object fields.
 type ValueDefaults struct {


### PR DESCRIPTION
This updates the dependency to version [936484377f0260b738a78173dcd56afbeb714d57](https://github.com/amp-labs/openapi/commit/936484377f0260b738a78173dcd56afbeb714d57) from [main](https://github.com/amp-labs/openapi/tree/main)