### PR TITLE
feat: local webhook listener + providers fixture event trigger 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 amp-labs
+Copyright (c) 2025 amp-labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If this doesn't work, then you'll need to add `/usr/local/bin` to your PATH vari
 
 You should also install the following linting tools by following the linked instructions:
 
-- <https://golangci-lint.run/usage/install/#local-installation>
+- <https://golangci-lint.run/welcome/install/>
 - <https://github.com/daixiang0/gci?tab=readme-ov-file#installation>
 - <https://github.com/bombsimon/wsl?tab=readme-ov-file#installation>
 

--- a/cmd/listen.go
+++ b/cmd/listen.go
@@ -1,0 +1,189 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/cli/internal/webhook"
+	"github.com/amp-labs/cli/logger"
+	"github.com/spf13/cobra"
+)
+
+var (
+	forwardURL    string
+	listenAddr    string
+	listenCommand = &cobra.Command{
+		Use:   "listen",
+		Short: "Listen for webhooks locally",
+		Long: `Listen for webhooks locally and forward them to your application.
+This command starts a local webhook server that receives events and forwards them to your application.
+It's designed for local development and testing.`,
+		RunE: runListen,
+	}
+)
+
+func init() {
+	listenCommand.Flags().StringVar(&forwardURL, "forward-to", "http://localhost:4000/webhook", "URL to forward webhooks to")
+	listenCommand.Flags().StringVar(&listenAddr, "listen", "127.0.0.1:0", "Address to listen on (default is random port)")
+	rootCmd.AddCommand(listenCommand)
+}
+
+func runListen(cmd *cobra.Command, args []string) error {
+	// Set up a context that we can cancel
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	// Set up the HTTP server
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", handleWebhook)
+
+	// Start the server
+	listener, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		return fmt.Errorf("failed to start listener: %w", err)
+	}
+
+	// Save the port for the trigger command to use
+	addr := listener.Addr().(*net.TCPAddr)
+	port := strconv.Itoa(addr.Port)
+	
+	// Save the port
+	if err := saveListenerPort(port); err != nil {
+		logger.FatalErr("failed to save port", err)
+	}
+	
+	srv := &http.Server{
+		Handler: mux,
+	}
+
+	// Start the server in a goroutine so it doesn't block
+	go func() {
+		logger.Info("starting webhook listener")
+		if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
+			logger.FatalErr("webhook listener failed", err)
+		}
+	}()
+
+	// Print the listen address
+	fmt.Printf("🎧 Listening on %s:%s\n", addr.IP, port)
+	fmt.Printf("ℹ️  Forwarding to: %s\n", forwardURL)
+	fmt.Println("Press Ctrl+C to stop")
+
+	// Wait for interrupt signal
+	<-ctx.Done()
+	fmt.Println("\nShutting down webhook listener...")
+
+	// Create a deadline to wait for current connections to complete
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		logger.FatalErr("shutdown error", err)
+	}
+
+	// Clean up the port file
+	clearListenerPort()
+
+	fmt.Println("Webhook listener stopped")
+	return nil
+}
+
+// saveListenerPort saves the listener port to a temporary file
+func saveListenerPort(port string) error {
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		return err
+	}
+	
+	// Create ampersand directory if it doesn't exist
+	ampDir := filepath.Join(dir, "ampersand")
+	if err := os.MkdirAll(ampDir, 0700); err != nil {
+		return err
+	}
+	
+	// Write port to file
+	portFile := filepath.Join(ampDir, "webhook-port")
+	return os.WriteFile(portFile, []byte(port), 0600)
+}
+
+// clearListenerPort removes the port file
+func clearListenerPort() {
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		return
+	}
+	
+	portFile := filepath.Join(dir, "ampersand", "webhook-port")
+	os.Remove(portFile) // Ignore errors
+}
+
+func handleWebhook(w http.ResponseWriter, r *http.Request) {
+	// Only accept POST requests
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Read the request body
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		logger.FatalErr("error reading request body", err)
+		http.Error(w, "Bad request", http.StatusBadRequest)
+		return
+	}
+	r.Body.Close()
+
+	// Log the webhook payload
+	webhook.PrettyPrintJSON(body)
+
+	// Forward the request to the application
+	req, err := http.NewRequest(http.MethodPost, forwardURL, bytes.NewReader(body))
+	if err != nil {
+		logger.FatalErr("error creating forward request", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	// Copy headers
+	for k, v := range r.Header {
+		if k == "Content-Length" {
+			continue
+		}
+		for _, vv := range v {
+			req.Header.Add(k, vv)
+		}
+	}
+
+	// Forward the request
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		logger.FatalErr(fmt.Sprintf("error forwarding request to %s", forwardURL), err)
+		// Still return 200 to the original sender
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Copy the response from the application back to the original sender
+	for k, v := range resp.Header {
+		for _, vv := range v {
+			w.Header().Add(k, vv)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		logger.FatalErr("error copying response", err)
+	}
+} 

--- a/cmd/trigger.go
+++ b/cmd/trigger.go
@@ -1,0 +1,185 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/amp-labs/cli/internal/webhook"
+	"github.com/amp-labs/cli/logger"
+	"github.com/spf13/cobra"
+)
+
+var (
+	fixtureFile     string
+	rawJSON         string
+	interactive     bool
+	listenPort      string
+	triggerCommand = &cobra.Command{
+		Use:   "trigger [provider.event]",
+		Short: "Trigger a webhook event",
+		Long: `Trigger a webhook event to be sent to the local listener.
+This command sends a webhook event to the local listener using fixture data.
+You can specify a built-in event or provide your own JSON payload.
+
+Examples:
+  amp trigger stripe.payment_intent.created
+  amp trigger hubspot.contact.created --interactive
+  amp trigger stripe.payment_intent.created --fixture ./my-custom-event.json
+  amp trigger custom.event --raw '{"key": "value"}'`,
+		Args: cobra.ExactArgs(1),
+		RunE: runTrigger,
+	}
+)
+
+func init() {
+	triggerCommand.Flags().StringVar(&fixtureFile, "fixture", "", "Path to a custom fixture file")
+	triggerCommand.Flags().StringVar(&rawJSON, "raw", "", "Raw JSON payload to send")
+	triggerCommand.Flags().BoolVar(&interactive, "interactive", false, "Open editor before sending")
+	triggerCommand.Flags().StringVar(&listenPort, "port", "", "Port of the local listener (default: auto-detect)")
+	rootCmd.AddCommand(triggerCommand)
+}
+
+func runTrigger(cmd *cobra.Command, args []string) error {
+	eventName := args[0]
+	provider, event := webhook.ParseEvent(eventName)
+	if event == "" {
+		return fmt.Errorf("invalid event format '%s', expected 'provider.event'", eventName)
+	}
+
+	// Determine which payload to use
+	var payload []byte
+	var err error
+
+	switch {
+	case rawJSON != "":
+		// Use raw JSON provided via command line
+		payload = []byte(rawJSON)
+		
+		// Validate it's valid JSON
+		var jsonObj interface{}
+		if err := json.Unmarshal(payload, &jsonObj); err != nil {
+			return fmt.Errorf("invalid JSON provided: %w", err)
+		}
+	case fixtureFile != "":
+		// Use custom fixture file
+		payload, err = webhook.LoadFixture(provider, event, fixtureFile)
+		if err != nil {
+			return err
+		}
+	default:
+		// Use built-in fixture
+		payload, err = webhook.LoadFixture(provider, event, "")
+		if err != nil {
+			return fmt.Errorf("no fixture found for %s.%s: %w", provider, event, err)
+		}
+	}
+
+	// Let user edit the payload if requested
+	if interactive {
+		payload, err = openInEditor(payload)
+		if err != nil {
+			return fmt.Errorf("failed to edit payload: %w", err)
+		}
+	}
+
+	// Send the webhook
+	fmt.Printf("🚀 Triggering webhook: %s\n", eventName)
+	return sendWebhook(payload)
+}
+
+// openInEditor opens the JSON payload in the default editor
+func openInEditor(data []byte) ([]byte, error) {
+	// Create a temporary file
+	tmpFile, err := os.CreateTemp("", "amp-webhook-*.json")
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(tmpFile.Name())
+
+	// Write the data to the file
+	if _, err := tmpFile.Write(data); err != nil {
+		return nil, err
+	}
+	if err := tmpFile.Close(); err != nil {
+		return nil, err
+	}
+
+	// Get the editor command
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		if runtime.GOOS == "windows" {
+			editor = "notepad"
+		} else {
+			editor = "vi"
+		}
+	}
+
+	// Open the editor
+	cmd := exec.Command(editor, tmpFile.Name())
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+
+	// Read the updated content
+	return os.ReadFile(tmpFile.Name())
+}
+
+// Send the webhook
+func sendWebhook(payload []byte) error {
+	port, err := getListenerPort()
+	if err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("http://127.0.0.1:%s", port)
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send the request
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send webhook: %w", err)
+	}
+	defer resp.Body.Close()
+
+	fmt.Printf("✅ Sent webhook → %d %s\n", resp.StatusCode, resp.Status)
+	return nil
+}
+
+func getListenerPort() (string, error) {
+	if listenPort != "" {
+		return listenPort, nil
+	}
+
+	// Try to get the port from the port file
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		logger.Debugf("error getting user cache dir: %v", err)
+		return "4242", nil // Default fallback port
+	}
+	
+	portFile := filepath.Join(dir, "ampersand", "webhook-port")
+	data, err := os.ReadFile(portFile)
+	if err != nil {
+		logger.Debug("could not find webhook port file, using default port 4242")
+		return "4242", nil // Default fallback port
+	}
+	
+	return strings.TrimSpace(string(data)), nil
+} 

--- a/internal/fixtures/hubspot/contact.created.json
+++ b/internal/fixtures/hubspot/contact.created.json
@@ -1,0 +1,22 @@
+{
+    "eventId": "hubspot-contact-201",
+    "subscriptionId": 1234567,
+    "portalId": 123456,
+    "occurredAt": "{{NOW}}",
+    "objectId": 201,
+    "properties": {
+        "firstname": "Chloe",
+        "lastname": "Smith",
+        "email": "chloe@example.com",
+        "phone": "+1-555-555-5555",
+        "company": "Example Corp"
+    },
+    "propertyVersions": {
+        "firstname": 0,
+        "lastname": 0,
+        "email": 0,
+        "phone": 0,
+        "company": 0
+    },
+    "eventType": "contact.creation"
+}

--- a/internal/fixtures/hubspot/deal.created.json
+++ b/internal/fixtures/hubspot/deal.created.json
@@ -1,0 +1,22 @@
+{
+    "eventId": "hubspot-deal-301",
+    "subscriptionId": 1234567,
+    "portalId": 123456,
+    "occurredAt": "{{NOW}}",
+    "objectId": 301,
+    "properties": {
+        "dealname": "New Enterprise Deal",
+        "dealstage": "presentationscheduled",
+        "amount": "50000",
+        "closedate": "{{NOW}}",
+        "pipeline": "default"
+    },
+    "propertyVersions": {
+        "dealname": 0,
+        "dealstage": 0,
+        "amount": 0,
+        "closedate": 0,
+        "pipeline": 0
+    },
+    "eventType": "deal.creation"
+}

--- a/internal/fixtures/stripe/customer.created.json
+++ b/internal/fixtures/stripe/customer.created.json
@@ -1,0 +1,18 @@
+{
+    "id": "evt_1OGbwdCZ6qsJgKboXHmcT7k8",
+    "object": "event",
+    "api_version": "2022-11-15",
+    "created": "{{NOW}}",
+    "data": {
+        "object": {
+            "id": "cus_O3hGjTKICiuGRp",
+            "object": "customer",
+            "email": "test@example.com",
+            "name": "Test Customer",
+            "created": "{{NOW}}",
+            "metadata": {}
+        }
+    },
+    "livemode": false,
+    "type": "customer.created"
+}

--- a/internal/fixtures/stripe/payment_intent.created.json
+++ b/internal/fixtures/stripe/payment_intent.created.json
@@ -1,0 +1,24 @@
+{
+    "id": "evt_1OGbwdCZ6qsJgKbogIQWTxsm",
+    "object": "event",
+    "api_version": "2022-11-15",
+    "created": "{{NOW}}",
+    "data": {
+        "object": {
+            "id": "pi_3NpDeuCZ6qsJgKbo0WZRi1g2",
+            "object": "payment_intent",
+            "amount": 2000,
+            "amount_details": {
+                "tip": {
+                    "amount": null
+                }
+            },
+            "currency": "usd",
+            "description": "Test payment",
+            "metadata": {},
+            "status": "succeeded"
+        }
+    },
+    "livemode": false,
+    "type": "payment_intent.created"
+}

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -1,0 +1,62 @@
+package webhook
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// LoadFixture loads a fixture file and replaces template placeholders
+func LoadFixture(provider, event, customPath string) ([]byte, error) {
+	var path string
+	if customPath != "" {
+		path = customPath
+	} else {
+		// Default path is in the internal fixtures directory
+		path = filepath.Join("internal", "fixtures", provider, event+".json")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read fixture file: %w", err)
+	}
+
+	// Replace template tokens
+	now := time.Now().UTC().Format(time.RFC3339)
+	data = bytes.ReplaceAll(data, []byte("{{NOW}}"), []byte(now))
+
+	// Validate it's valid JSON
+	var jsonObj interface{}
+	if err := json.Unmarshal(data, &jsonObj); err != nil {
+		return nil, fmt.Errorf("fixture contains invalid JSON: %w", err)
+	}
+
+	return data, nil
+}
+
+// ParseEvent parses an event string into provider and event name
+// Format: provider.event_name (e.g., "stripe.payment_intent.created")
+func ParseEvent(event string) (provider, eventName string) {
+	parts := strings.SplitN(event, ".", 2)
+	if len(parts) < 2 {
+		return event, ""
+	}
+	return parts[0], parts[1]
+}
+
+// PrettyPrintJSON formats and prints JSON data to stdout with colors
+func PrettyPrintJSON(data []byte) error {
+	var prettyJSON bytes.Buffer
+	err := json.Indent(&prettyJSON, data, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("\n→ Received webhook event:\n%s\n", prettyJSON.String())
+	fmt.Println("------------------------------------------")
+	return nil
+} 

--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2023 NAME HERE <EMAIL ADDRESS>
+Copyright © 2025 amp-labs
 */
 package main
 


### PR DESCRIPTION
## Overview

This PR adds local webhook development and testing capabilities with two new commands:

- `amp listen` - Starts a local webhook server that forwards incoming webhooks to your application
- `amp trigger` - Sends test webhook events to the listener

<div>
    <a href="https://www.loom.com/share/35fea7a34d4f4784938e96d1b84de940">
      <p>Terminal - cli — -zsh — 253×24 - 14 May 2025 - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/35fea7a34d4f4784938e96d1b84de940">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/35fea7a34d4f4784938e96d1b84de940-3a10c0a254ed7d2d-full-play.gif">
    </a>
  </div>

## Features

- Local webhook server that forwards to your application
- Built-in fixtures for common webhook providers (Stripe, HubSpot)
- Interactive mode to edit payloads before sending
- Support for custom fixtures and raw JSON payloads
- Pretty-printing of webhook events

## Additional Changes

- Updated installation link for golangci-lint in README
- Updated copyright year in LICENSE and main.go 