### PR TITLE
feat: add the sync-ngrok command

### DIFF
--- a/cmd/ngrok.go
+++ b/cmd/ngrok.go
@@ -19,24 +19,46 @@ import (
 )
 
 var (
+	// destinations stores the list of destination names or IDs provided via command-line flags.
+	// These can be either destination names (human-readable) or UUIDs (unique identifiers).
 	destinations []string
-	skipConfirm  bool
+
+	// skipConfirm determines whether to skip user confirmation prompts when updating destinations.
+	// When true, the command will automatically proceed with all updates without asking for confirmation.
+	skipConfirm bool
+
+	// ngrokCommand defines the Cobra command structure for the ngrok subcommand.
+	// This command is hidden from the main help output as it's primarily for development use.
 	ngrokCommand = &cobra.Command{
 		Use:    "ngrok",
-		Short:  "Ngrok tunnel management",
+		Short:  "Automatic ngrok URL configuration for Ampersand destinations",
 		Long:   "Configure Ampersand destinations to use ngrok tunnels for local development.",
-		Hidden: true,
+		Hidden: true, // Hidden because it's a development-only feature
 		RunE:   runNgrok,
 	}
 )
 
+// Destination represents a webhook destination in the Ampersand platform.
+// It contains the essential information needed to identify and update a destination's URL.
 type Destination struct {
-	Id   string `json:"id"`
+	// Id is the unique UUID identifier for the destination in Ampersand
+	Id string `json:"id"`
+
+	// Name is the human-readable name assigned to the destination (optional)
 	Name string `json:"name"`
-	URL  string `json:"url"`
+
+	// URL is the current webhook URL where events are sent
+	URL string `json:"url"`
+
+	// Type indicates the kind of destination, typically "webhook" for webhook destinations
+	Type string `json:"type"` // Type of the destination (e.g., "webhook")
 }
 
+// String returns a human-readable representation of the destination.
+// If a name is available, it returns "Name (ID)", otherwise just the ID.
+// This method implements the Stringer interface for better display in prompts and logs.
 func (d Destination) String() string {
+	// Prefer showing name with ID for clarity, fallback to just ID
 	if d.Name != "" {
 		return fmt.Sprintf("%s (%s)", d.Name, d.Id)
 	}
@@ -44,69 +66,106 @@ func (d Destination) String() string {
 	return d.Id
 }
 
+// ngrokTunnel represents a single tunnel from ngrok's API response.
+// Contains the public URL that ngrok has assigned to forward traffic to the local service.
 type ngrokTunnel struct {
+	// PublicURL is the externally accessible URL that ngrok provides
+	// (e.g., "https://abc123.ngrok.io")
 	PublicURL string `json:"public_url"`
 }
 
+// ngrokResponse represents the JSON response from ngrok's local API endpoint.
+// The ngrok agent exposes an API at localhost:4040 that provides information about active tunnels.
 type ngrokResponse struct {
+	// Tunnels is an array of all currently active ngrok tunnels
 	Tunnels []ngrokTunnel `json:"tunnels"`
 }
 
+// init initializes the ngrok command by setting up command-line flags and
+// registering the command with the root command. This function is called
+// automatically when the package is imported.
 func init() {
+	// Set up the destination flag to accept multiple destination identifiers
+	// Users can specify destinations by name or UUID, multiple times or comma-separated
 	ngrokCommand.Flags().StringSliceVarP(&destinations,
 		"destination", "D", []string{},
 		"Destination names or IDs (UUIDs)")
 
+	// Set up the confirmation skip flag for automated workflows
 	ngrokCommand.Flags().BoolVarP(&skipConfirm,
 		"yes", "y", false,
 		"Skip confirmation prompts")
 
+	// Register this command as a subcommand of the root CLI command
 	rootCmd.AddCommand(ngrokCommand)
 }
 
+// getPublicNgrokUrl retrieves the public URL of an active ngrok tunnel by querying
+// the ngrok local API endpoint. If multiple tunnels exist, it prompts the user to choose one.
+// Returns the selected tunnel's public URL or an error if ngrok is not accessible.
 func getPublicNgrokUrl(ctx context.Context) (string, error) {
+	// Create HTTP request to ngrok's local API endpoint
+	// The ngrok agent exposes a REST API on port 4040 by default
 	req, err := http.NewRequestWithContext(ctx, "GET", "http://localhost:4040/api/tunnels", nil)
 	if err != nil {
+		// Wrap the error with context about what operation failed
 		return "", fmt.Errorf("failed to create ngrok API request: %w", err)
 	}
 
+	// Execute the HTTP request to get tunnel information
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
+		// This error typically means ngrok is not running or not accessible
 		return "", fmt.Errorf("failed to connect to ngrok API: %w", err)
 	}
 
+	// Ensure response body is properly closed to prevent resource leaks
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "error closing response body: %v\n", closeErr)
 		}
 	}()
 
+	// Check if the ngrok API responded successfully
 	if resp.StatusCode != http.StatusOK {
+		// Non-200 status codes indicate ngrok API issues
 		return "", fmt.Errorf("ngrok API returned status %d", resp.StatusCode)
 	}
 
+	// Parse the JSON response containing tunnel information
 	var ngrokResp ngrokResponse
 	if err := json.NewDecoder(resp.Body).Decode(&ngrokResp); err != nil {
+		// JSON parsing errors indicate malformed response from ngrok
 		return "", fmt.Errorf("failed to parse ngrok response: %w", err)
 	}
 
+	// Handle tunnel selection (single tunnel vs. multiple tunnels)
 	return chooseNgrokTunnel(&ngrokResp)
 }
 
+// chooseNgrokTunnel handles tunnel selection when multiple ngrok tunnels are active.
+// If only one tunnel exists, it returns that tunnel's URL automatically.
+// If multiple tunnels exist, it presents an interactive prompt for the user to choose.
+// Returns the selected tunnel's public URL or an error if selection fails.
 func chooseNgrokTunnel(ngrokResp *ngrokResponse) (string, error) {
+	// Validate that at least one tunnel is available
 	if len(ngrokResp.Tunnels) == 0 {
+		// This means ngrok is running but no tunnels are active
 		return "", fmt.Errorf("no ngrok tunnels found")
 	}
 
+	// If only one tunnel exists, use it automatically (no need to prompt)
 	if len(ngrokResp.Tunnels) == 1 {
 		return ngrokResp.Tunnels[0].PublicURL, nil
 	}
 
+	// Extract URLs from tunnels for user selection
 	urls := make([]string, len(ngrokResp.Tunnels))
 	for i, tunnel := range ngrokResp.Tunnels {
 		urls[i] = tunnel.PublicURL
 	}
 
+	// Present interactive selection prompt for multiple tunnels
 	prompt := promptui.Select{
 		Label:  "Choose ngrok tunnel",
 		Items:  urls,
@@ -114,54 +173,74 @@ func chooseNgrokTunnel(ngrokResp *ngrokResponse) (string, error) {
 		Stdout: os.Stdout,
 	}
 
+	// Get user's tunnel selection
 	idx, _, err := prompt.Run()
 	if err != nil {
+		// User cancelled selection or prompt failed
 		return "", fmt.Errorf("failed to select tunnel: %w", err)
 	}
 
 	return urls[idx], nil
 }
 
+// waitForNgrok waits for the ngrok service to become available on localhost:4040.
+// It performs an initial connectivity check, and if ngrok is not immediately available,
+// it retries with a timeout and visual progress indicator (dots).
+// Returns nil when ngrok is accessible, or an error if the timeout is exceeded.
 func waitForNgrok(ctx context.Context) error {
+	// Configuration constants for ngrok availability checking
 	const (
-		maxDuration   = 5 * time.Minute
-		retryInterval = 2 * time.Second
-		address       = "localhost:4040"
+		maxDuration   = 5 * time.Minute  // Maximum time to wait for ngrok
+		retryInterval = 2 * time.Second  // Time between connection attempts
+		address       = "localhost:4040" // Standard ngrok API address
 	)
 
+	// Perform initial connectivity check to see if ngrok is already running
 	conn, err := net.DialTimeout("tcp", address, time.Second)
 	if err == nil {
-		conn.Close()
+		// ngrok is already available, close connection and return immediately
+		_ = conn.Close()
 		return nil
 	}
 
+	// Set up retry loop with timeout and progress indication
 	deadline := time.Now().Add(maxDuration)
 	ticker := time.NewTicker(retryInterval)
 	defer ticker.Stop()
 
+	// Track if we need to add a newline after progress dots
 	needsNewline := false
 
+	// Ensure we clean up the progress display when function exits
 	defer func() {
 		if needsNewline {
 			_, _ = os.Stdout.Write([]byte("\n"))
 		}
 	}()
 
+	// Main retry loop with context cancellation and timeout handling
 	for {
 		select {
 		case <-ctx.Done():
+			// Context was cancelled (e.g., user pressed Ctrl+C)
+			// Return the context error (e.g., context.Canceled, context.DeadlineExceeded)
 			return ctx.Err()
 		case <-ticker.C:
+			// Check if we've exceeded the maximum wait time
 			if time.Now().After(deadline) {
+				// Return timeout error with specific details for debugging
 				return fmt.Errorf("timeout waiting for ngrok on %s after %v", address, maxDuration)
 			}
 
+			// Attempt to connect to ngrok API endpoint
 			conn, err := net.DialTimeout("tcp", address, time.Second)
 			if err == nil {
-				conn.Close()
+				// Success! ngrok is now available
+				_ = conn.Close()
 				return nil
 			}
 
+			// Show progress indicator (dot) and continue waiting
 			_, _ = os.Stdout.Write([]byte("."))
 			_ = os.Stdout.Sync()
 			needsNewline = true
@@ -169,202 +248,294 @@ func waitForNgrok(ctx context.Context) error {
 	}
 }
 
+// runNgrok is the main entry point for the ngrok command execution.
+// It orchestrates the entire process: setup, ngrok tunnel discovery, and destination updates.
+// This function is called by the Cobra framework when the ngrok command is invoked.
 func runNgrok(cmd *cobra.Command, _ []string) error {
+	// Phase 1: Initialize API client and resolve destination identifiers
 	client, dests, err := setupNgrokExecution(cmd.Context())
 	if err != nil {
+		// Setup errors are passed through directly as they already have context
 		return err
 	}
 
+	// Phase 2: Wait for ngrok and get the public tunnel URL
 	publicURL, err := getNgrokTunnelURL(cmd.Context())
 	if err != nil {
+		// Ngrok-related errors are passed through with their original context
 		return err
 	}
 
+	// Phase 3: Update all specified destinations with the ngrok URL
 	stats := updateDestinations(cmd.Context(), client, dests, publicURL)
 
+	// Phase 4: Report the results to the user
 	logDestinationStats(stats, len(dests))
 
 	return nil
 }
 
+// setupNgrokExecution initializes the necessary components for ngrok command execution.
+// It creates an API client with the current project context and resolves the provided
+// destination identifiers to canonical destination objects.
+// Returns the API client, resolved destinations, and any setup errors.
 func setupNgrokExecution(ctx context.Context) (*request.APIClient, []Destination, error) {
+	// Get the current project context and API credentials
 	projectId := flags.GetProjectOrFail()
 	apiKey := flags.GetAPIKey()
 	client := request.NewAPIClient(projectId, &apiKey)
 
+	// Resolve user-provided destination identifiers to actual destination objects
 	dests, err := getCanonicalDestinations(ctx, client)
 	if err != nil {
+		// Add context about this specific operation failure
 		return nil, nil, fmt.Errorf("failed to get canonical destinations: %w", err)
 	}
 
+	// Validate that we have at least one destination to work with
 	if len(dests) == 0 {
+		// This indicates user provided invalid destination identifiers
 		return nil, nil, fmt.Errorf("no valid destinations provided")
 	}
 
 	return client, dests, nil
 }
 
+// getNgrokTunnelURL manages the process of waiting for ngrok to start and retrieving
+// the public tunnel URL. It provides user feedback during the wait process and
+// handles the tunnel URL selection if multiple tunnels are available.
+// Returns the selected ngrok public URL or an error if the process fails.
 func getNgrokTunnelURL(ctx context.Context) (string, error) {
+	// Step 1: Wait for ngrok service to become available
 	logger.Info("waiting for ngrok to start...")
 
 	if err := waitForNgrok(ctx); err != nil {
+		// Provide helpful context about ngrok not being available
 		return "", fmt.Errorf("ngrok is not running: %w", err)
 	}
 
+	// Step 2: Query ngrok API for active tunnels and get public URL
 	logger.Info("ngrok is running, fetching public URL...")
 
 	publicURL, err := getPublicNgrokUrl(ctx)
 	if err != nil {
+		// Add context about URL retrieval failure
 		return "", fmt.Errorf("failed to get public ngrok URL: %w", err)
 	}
 
+	// Step 3: Display the selected ngrok URL
 	logger.Infof("Public ngrok URL: %s", publicURL)
 
 	return publicURL, nil
 }
 
+// destinationStats tracks the outcome of destination update operations.
+// It provides a summary of how many destinations were processed in each category.
 type destinationStats struct {
-	skipped   int
+	// skipped counts destinations that were not updated (user declined or errors occurred)
+	skipped int
+
+	// unchanged counts destinations that already had the correct ngrok URL
 	unchanged int
-	updated   int
+
+	// updated counts destinations that were successfully updated with the new ngrok URL
+	updated int
 }
 
+// updateDestinations processes a list of destinations and updates their URLs to point
+// to the provided ngrok public URL. For each destination, it checks if an update is needed,
+// prompts for user confirmation (unless skipped), and performs the update via the API.
+// Returns statistics about the update operation (updated, skipped, unchanged counts).
 func updateDestinations(ctx context.Context, client *request.APIClient, dests []Destination, publicURL string) destinationStats {
+	// Initialize statistics tracking
 	stats := destinationStats{}
 
+	// Process each destination individually
 	for _, dest := range dests {
+		// Skip destinations that already have the correct URL
 		if dest.URL == publicURL {
 			stats.unchanged++
 			continue
 		}
 
+		// Ask user for confirmation (unless --yes flag is used)
 		shouldUpdate, err := promptUpdateDestination(dest.String(), publicURL)
 		if err != nil {
+			// Log prompt failures but continue with other destinations
 			logger.Info(fmt.Sprintf("failed to prompt for destination update: %v", err))
 			stats.skipped++
 			continue
 		}
 
+		// Respect user's decision to skip this destination
 		if !shouldUpdate {
 			stats.skipped++
 			continue
 		}
 
+		// Attempt to update the destination via API
 		if err := updateDestination(ctx, client, dest, publicURL); err != nil {
+			// Log API update failures but continue with other destinations
 			logger.Info(fmt.Sprintf("failed to update destination %s: %v", dest.String(), err))
 			stats.skipped++
 			continue
 		}
 
+		// Successfully updated this destination
 		stats.updated++
 	}
 
 	return stats
 }
 
+// updateDestination performs the actual API call to update a single destination's URL.
+// It uses the PATCH endpoint to modify only the metadata.url field of the destination,
+// preserving all other destination configuration.
+// Returns an error if the API call fails.
 func updateDestination(ctx context.Context, client *request.APIClient, dest Destination, publicURL string) error {
+	// Log the update operation for user visibility
 	logger.Infof("Changing webhook destination %s to %s", dest.Name, publicURL)
 
+	// Make API call to update the destination's URL
+	// Using PATCH with update mask to only modify the URL field
 	_, err := client.PatchDestination(ctx, dest.Id, &request.PatchDestination{
 		Destination: map[string]any{
 			"metadata": map[string]any{
 				"url": publicURL,
 			},
 		},
-		UpdateMask: []string{"metadata.url"},
+		UpdateMask: []string{"metadata.url"}, // Only update the URL field
 	})
 
 	return err
 }
 
+// logDestinationStats outputs a summary of the destination update operation.
+// It provides a clear breakdown of how many destinations were processed in each category,
+// helping users understand the results of the ngrok command execution.
 func logDestinationStats(stats destinationStats, total int) {
 	logger.Infof("Total destinations: %d, unchanged: %d, skipped: %d, updated: %d",
 		total, stats.unchanged, stats.skipped, stats.updated)
 }
 
+// getCanonicalDestinations resolves user-provided destination identifiers (names or IDs)
+// into canonical Destination objects by querying the Ampersand API. It supports matching
+// by both destination name and UUID, and only includes webhook-type destinations.
+// Returns a slice of resolved destinations or an error if any identifier is invalid.
 func getCanonicalDestinations(ctx context.Context, client *request.APIClient) ([]Destination, error) {
+	// Filter out empty destination strings from command-line input
 	inputs := make([]string, 0, len(destinations))
 	for _, dest := range destinations {
 		if dest == "" {
-			continue
+			continue // Skip empty strings
 		}
 
 		inputs = append(inputs, dest)
 	}
 
+	// Validate that we have at least one destination to process
 	if len(inputs) == 0 {
+		// This means user didn't provide any destination flags or all were empty
 		return nil, fmt.Errorf("no valid destinations provided")
 	}
 
+	// Fetch all destinations from the Ampersand API
 	ampDests, err := client.ListDestinations(ctx)
 	if err != nil {
+		// API call failed - could be network, auth, or server issues
 		return nil, fmt.Errorf("failed to list destinations: %w", err)
 	}
 
+	// Create lookup maps for efficient destination resolution
+	// Support both name-based and ID-based lookups
 	ampNameMap := make(map[string]Destination)
 	ampIdMap := make(map[string]Destination)
 
+	// Build lookup maps from API response
 	for _, d := range ampDests {
-		if d.Type != "webhook" {
-			continue // Only consider webhook destinations
-		}
-
+		// Add to ID-based lookup (case-insensitive for UUIDs)
 		ampIdMap[strings.ToLower(d.Id)] = Destination{
 			Id:   d.Id,
 			Name: d.Name,
 			URL:  d.Metadata.URL,
+			Type: d.Type,
 		}
 
+		// Add to name-based lookup if destination has a name
 		if d.Name != "" {
 			ampNameMap[d.Name] = Destination{
 				Id:   d.Id,
 				Name: d.Name,
 				URL:  d.Metadata.URL,
+				Type: d.Type,
 			}
 		}
 	}
 
+	// Resolve each input to a canonical destination object
 	canonical := make([]Destination, 0, len(inputs))
 
 	for _, input := range inputs {
-		// Is it a known ID? If so add it.
+		// Try to match by ID first (case-insensitive)
 		if dest, ok := ampIdMap[strings.ToLower(input)]; ok {
+			if dest.Type != "webhook" {
+				// If the destination is not a webhook, skip it
+				return nil, fmt.Errorf("destination %s is not a webhook", input)
+			}
+
 			canonical = append(canonical, dest)
 			continue
 		}
 
-		// Is it a known name? If so, add it.
+		// Try to match by name (exact match)
 		if dest, ok := ampNameMap[input]; ok {
+			if dest.Type != "webhook" {
+				// If the destination is not a webhook, skip it
+				return nil, fmt.Errorf("destination %s is not a webhook", input)
+			}
+
 			canonical = append(canonical, dest)
 			continue
 		}
 
+		// Input doesn't match any known destination name or ID
+		// Provide specific error to help user identify the issue
 		return nil, fmt.Errorf("invalid destination: %s", input)
 	}
 
 	return canonical, nil
 }
 
+// promptUpdateDestination asks the user for confirmation before updating a destination's URL.
+// If the skipConfirm flag is set, it automatically returns true without prompting.
+// Otherwise, it presents an interactive yes/no prompt to the user.
+// Returns true if the user confirms the update, false if declined, or an error if the prompt fails.
 func promptUpdateDestination(dest, url string) (bool, error) {
+	// If skip confirmation flag is set, automatically approve all updates
 	if skipConfirm {
 		return true, nil
 	}
 
+	// Present interactive confirmation prompt to user
 	prompter := promptui.Prompt{
 		Label:     "Change destination '" + dest + "' to '" + url + "'",
-		IsConfirm: true,
+		IsConfirm: true, // Makes this a yes/no prompt
 		Stdin:     os.Stdin,
 		Stdout:    os.Stdout,
 	}
 
+	// Execute the prompt and handle user response
 	_, err := prompter.Run()
 	if err != nil {
+		// User pressed Ctrl+C or said "no" - not an error condition
 		if errors.Is(err, promptui.ErrAbort) {
 			return false, nil
 		}
 
+		// Actual error occurred during prompting (e.g., stdin issues)
 		return false, err
 	}
 
+	// User confirmed the update
 	return true, nil
 }

--- a/cmd/ngrok.go
+++ b/cmd/ngrok.go
@@ -1,0 +1,330 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/amp-labs/cli/flags"
+	"github.com/amp-labs/cli/logger"
+	"github.com/amp-labs/cli/request"
+	"github.com/manifoldco/promptui"
+	"github.com/spf13/cobra"
+)
+
+var (
+	destinations []string
+	skipConfirm  bool
+	ngrokCommand = &cobra.Command{
+		Use:    "ngrok",
+		Short:  "Ngrok tunnel management",
+		Long:   "Configure Ampersand destinations to use ngrok tunnels for local development.",
+		Hidden: true,
+		RunE:   runNgrok,
+	}
+)
+
+type Destination struct {
+	Id   string `json:"id"`
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+func (d Destination) String() string {
+	if d.Name != "" {
+		return fmt.Sprintf("%s (%s)", d.Name, d.Id)
+	}
+
+	return d.Id
+}
+
+type ngrokTunnel struct {
+	PublicURL string `json:"public_url"`
+}
+
+type ngrokResponse struct {
+	Tunnels []ngrokTunnel `json:"tunnels"`
+}
+
+func init() {
+	ngrokCommand.Flags().StringSliceVarP(&destinations,
+		"destination", "D", []string{},
+		"Destination names or IDs (UUIDs)")
+
+	ngrokCommand.Flags().BoolVarP(&skipConfirm,
+		"yes", "y", false,
+		"Skip confirmation prompts")
+
+	rootCmd.AddCommand(ngrokCommand)
+}
+
+func getPublicNgrokUrl(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://localhost:4040/api/tunnels", nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create ngrok API request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to connect to ngrok API: %w", err)
+	}
+
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "error closing response body: %v\n", closeErr)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("ngrok API returned status %d", resp.StatusCode)
+	}
+
+	var ngrokResp ngrokResponse
+	if err := json.NewDecoder(resp.Body).Decode(&ngrokResp); err != nil {
+		return "", fmt.Errorf("failed to parse ngrok response: %w", err)
+	}
+
+	return chooseNgrokTunnel(&ngrokResp)
+}
+
+func chooseNgrokTunnel(ngrokResp *ngrokResponse) (string, error) {
+	if len(ngrokResp.Tunnels) == 0 {
+		return "", fmt.Errorf("no ngrok tunnels found")
+	}
+
+	if len(ngrokResp.Tunnels) == 1 {
+		return ngrokResp.Tunnels[0].PublicURL, nil
+	}
+
+	urls := make([]string, len(ngrokResp.Tunnels))
+	for i, tunnel := range ngrokResp.Tunnels {
+		urls[i] = tunnel.PublicURL
+	}
+
+	prompt := promptui.Select{
+		Label:  "Choose ngrok tunnel",
+		Items:  urls,
+		Stdin:  os.Stdin,
+		Stdout: os.Stdout,
+	}
+
+	idx, _, err := prompt.Run()
+	if err != nil {
+		return "", fmt.Errorf("failed to select tunnel: %w", err)
+	}
+
+	return urls[idx], nil
+}
+
+func waitForNgrok(ctx context.Context) error {
+	const (
+		maxDuration   = 5 * time.Minute
+		retryInterval = 2 * time.Second
+		address       = "localhost:4040"
+	)
+
+	conn, err := net.DialTimeout("tcp", address, time.Second)
+	if err == nil {
+		conn.Close()
+		return nil
+	}
+
+	deadline := time.Now().Add(maxDuration)
+	ticker := time.NewTicker(retryInterval)
+	defer ticker.Stop()
+
+	needsNewline := false
+
+	defer func() {
+		if needsNewline {
+			_, _ = os.Stdout.Write([]byte("\n"))
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if time.Now().After(deadline) {
+				return fmt.Errorf("timeout waiting for ngrok on %s after %v", address, maxDuration)
+			}
+
+			conn, err := net.DialTimeout("tcp", address, time.Second)
+			if err == nil {
+				conn.Close()
+				return nil
+			}
+
+			_, _ = os.Stdout.Write([]byte("."))
+			_ = os.Stdout.Sync()
+			needsNewline = true
+		}
+	}
+}
+
+func runNgrok(cmd *cobra.Command, _ []string) error {
+	projectId := flags.GetProjectOrFail()
+	apiKey := flags.GetAPIKey()
+
+	client := request.NewAPIClient(projectId, &apiKey)
+
+	dests, err := getCanonicalDestinations(cmd.Context(), client)
+	if err != nil {
+		return fmt.Errorf("failed to get canonical destinations: %w", err)
+	}
+
+	if len(dests) == 0 {
+		return fmt.Errorf("no valid destinations provided")
+	}
+
+	logger.Info("waiting for ngrok to start...")
+
+	if err := waitForNgrok(cmd.Context()); err != nil {
+		return fmt.Errorf("ngrok is not running: %w", err)
+	}
+
+	logger.Info("ngrok is running, fetching public URL...")
+
+	publicURL, err := getPublicNgrokUrl(cmd.Context())
+	if err != nil {
+		return fmt.Errorf("failed to get public ngrok URL: %w", err)
+	}
+
+	logger.Infof("Public ngrok URL: %s", publicURL)
+
+	skipped := 0
+	unchanged := 0
+	updated := 0
+
+	for _, dest := range dests {
+		if dest.URL == publicURL {
+			unchanged++
+			continue
+		}
+
+		shouldUpdate, err := promptUpdateDestination(dest.String(), publicURL)
+		if err != nil {
+			return fmt.Errorf("failed to prompt for destination update: %w", err)
+		}
+
+		if !shouldUpdate {
+			skipped++
+			continue
+		}
+
+		logger.Infof("Changing webhook destination %s to %s", dest.Name, publicURL)
+
+		_, err = client.PatchDestination(cmd.Context(), dest.Id, &request.PatchDestination{
+			Destination: map[string]any{
+				"metadata": map[string]any{
+					"url": publicURL,
+				},
+			},
+			UpdateMask: []string{"metadata.url"},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to update destination %s: %w", dest.String(), err)
+		}
+
+		updated++
+	}
+
+	logger.Infof("Total destinations: %d, unchanged: %d, skipped: %d, updated: %d",
+		len(dests), unchanged, skipped, updated)
+
+	return nil
+}
+
+func getCanonicalDestinations(ctx context.Context, client *request.APIClient) ([]Destination, error) {
+	inputs := make([]string, 0, len(destinations))
+	for _, dest := range destinations {
+		if dest == "" {
+			continue
+		}
+
+		inputs = append(inputs, dest)
+	}
+
+	if len(inputs) == 0 {
+		return nil, fmt.Errorf("no valid destinations provided")
+	}
+
+	ampDests, err := client.ListDestinations(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list destinations: %w", err)
+	}
+
+	ampNameMap := make(map[string]Destination)
+	ampIdMap := make(map[string]Destination)
+
+	for _, d := range ampDests {
+		if d.Type != "webhook" {
+			continue // Only consider webhook destinations
+		}
+
+		ampIdMap[strings.ToLower(d.Id)] = Destination{
+			Id:   d.Id,
+			Name: d.Name,
+			URL:  d.Metadata.URL,
+		}
+
+		if d.Name != "" {
+			ampNameMap[d.Name] = Destination{
+				Id:   d.Id,
+				Name: d.Name,
+				URL:  d.Metadata.URL,
+			}
+		}
+	}
+
+	canonical := make([]Destination, 0, len(inputs))
+
+	for _, input := range inputs {
+		// Is it a known ID? If so add it.
+		if dest, ok := ampIdMap[strings.ToLower(input)]; ok {
+			canonical = append(canonical, dest)
+			continue
+		}
+
+		// Is it a known name? If so, add it.
+		if dest, ok := ampNameMap[input]; ok {
+			canonical = append(canonical, dest)
+			continue
+		}
+
+		return nil, fmt.Errorf("invalid destination: %s", input)
+	}
+
+	return canonical, nil
+}
+
+func promptUpdateDestination(dest, url string) (bool, error) {
+	if skipConfirm {
+		return true, nil
+	}
+
+	prompter := promptui.Prompt{
+		Label:     "Change destination '" + dest + "' to '" + url + "'",
+		IsConfirm: true,
+		Stdin:     os.Stdin,
+		Stdout:    os.Stdout,
+	}
+
+	_, err := prompter.Run()
+	if err != nil {
+		if errors.Is(err, promptui.ErrAbort) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
+}

--- a/cmd/ngrok.go
+++ b/cmd/ngrok.go
@@ -523,7 +523,7 @@ func updateDestination(ctx context.Context, client *request.APIClient, dest Dest
 	}
 
 	// Log the update operation for user visibility
-	logger.Infof("Changing webhook destination %s to %s", dest.Name, mergedURL)
+	logger.Infof("Changing webhook destination %s to %s", dest.String(), mergedURL)
 
 	// Make API call to update the destination's URL
 	// Using PATCH with update mask to only modify the URL field

--- a/cmd/ngrok.go
+++ b/cmd/ngrok.go
@@ -658,7 +658,7 @@ func resolveDestination(input string, ampNameMap, ampIdMap map[string]Destinatio
 	}
 
 	// Try to match by name (exact match)
-	if dest, ok := ampNameMap[input]; ok {
+	if dest, ok := ampNameMap[strings.ToLower(input)]; ok {
 		return validateWebhookDestination(dest, input)
 	}
 

--- a/cmd/ngrok.go
+++ b/cmd/ngrok.go
@@ -200,13 +200,11 @@ func getPublicNgrokURLWithRetry(ctx context.Context) (string, error) {
 func getPublicNgrokURL(ctx context.Context) (string, error) {
 	// Create HTTP request to ngrok's API endpoint
 	// The ngrok agent exposes a REST API, typically on port 4040 by default
-	var apiURL strings.Builder
-
-	apiURL.WriteString(ngrokProtocol)
-	apiURL.WriteString("://")
-	apiURL.WriteString(ngrokServer)
-	apiURL.WriteString("/api/tunnels")
-
+	apiURL := url.URL{
+		Scheme: ngrokProtocol,
+		Host:   ngrokServer,
+		Path:   "/api/tunnels",
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL.String(), nil)
 	if err != nil {
 		// Wrap the error with context about what operation failed

--- a/cmd/ngrok.go
+++ b/cmd/ngrok.go
@@ -236,9 +236,6 @@ func getPublicNgrokURL(ctx context.Context) (string, error) {
 	// Parse the JSON response containing tunnel information
 	var ngrokResp ngrokResponse
 	decoder := json.NewDecoder(resp.Body)
-	if decoder == nil {
-		return "", errJSONDecoderCreate
-	}
 
 	if err := decoder.Decode(&ngrokResp); err != nil {
 		// JSON parsing errors indicate malformed response from ngrok

--- a/cmd/sync_ngrok.go
+++ b/cmd/sync_ngrok.go
@@ -638,7 +638,7 @@ func buildDestinationMaps(ampDests []*request.Destination) (map[string]Destinati
 		ampIdMap[strings.ToLower(destination.Id)] = dest
 
 		if destination.Name != "" {
-			ampNameMap[destination.Name] = dest
+			ampNameMap[strings.ToLower(destination.Name)] = dest
 		}
 	}
 

--- a/cmd/sync_ngrok.go
+++ b/cmd/sync_ngrok.go
@@ -342,7 +342,7 @@ func waitForNgrok(ctx context.Context) error {
 			// Check if we've exceeded the maximum wait time
 			if time.Now().After(deadline) {
 				// Return timeout error with specific details for debugging
-				return fmt.Errorf("%s on %s after %v",
+				return fmt.Errorf("%w on %s after %v",
 					errDeadlineExceeded, address, maxWaitDuration)
 			}
 

--- a/cmd/sync_ngrok.go
+++ b/cmd/sync_ngrok.go
@@ -29,7 +29,7 @@ const (
 )
 
 var (
-	// Static errors for linter compliance
+	// Static errors for linter compliance.
 	errProtocolEmpty         = errors.New("protocol cannot be empty")
 	errInvalidProtocol       = errors.New("invalid protocol: must be 'http' or 'https'")
 	errNgrokServerEmpty      = errors.New("ngrok server cannot be empty")
@@ -190,13 +190,13 @@ func getPublicNgrokURLWithRetry(ctx context.Context) (string, error) {
 				maxRetryDuration.String(), err)
 		}
 
-		// Check if context was cancelled
+		// Check if context was canceled
 		select {
 		case <-ctx.Done():
 			return "", ctx.Err()
 		case <-time.After(delay):
-			// Continue to next retry attempt
 		}
+
 		// Exponential backoff with cap
 		delay *= 2
 		if delay > maxDelay {
@@ -216,6 +216,7 @@ func getPublicNgrokURL(ctx context.Context) (string, error) {
 		Host:   ngrokServer,
 		Path:   "/api/tunnels",
 	}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL.String(), nil)
 	if err != nil {
 		// Wrap the error with context about what operation failed
@@ -244,6 +245,7 @@ func getPublicNgrokURL(ctx context.Context) (string, error) {
 
 	// Parse the JSON response containing tunnel information
 	var ngrokResp ngrokResponse
+
 	decoder := json.NewDecoder(resp.Body)
 
 	if err := decoder.Decode(&ngrokResp); err != nil {
@@ -288,7 +290,7 @@ func chooseNgrokTunnel(ngrokResp *ngrokResponse) (string, error) {
 	// Get user's tunnel selection
 	idx, _, err := prompt.Run()
 	if err != nil {
-		// User cancelled selection or prompt failed
+		// User canceled selection or prompt failed
 		return "", fmt.Errorf("failed to select tunnel: %w", err)
 	}
 
@@ -335,7 +337,7 @@ func waitForNgrok(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			// Context was cancelled (e.g., user pressed Ctrl+C)
+			// Context was canceled (e.g., user pressed Ctrl+C)
 			// Return the context error (e.g., context.Canceled, context.DeadlineExceeded)
 			return ctx.Err()
 		case <-ticker.C:
@@ -479,7 +481,9 @@ func updateDestinations(ctx context.Context, client *request.APIClient,
 			// Log URL merge failures but continue with other destinations
 			logger.Infof("failed to merge URLs for destination %s: %v",
 				dest.NameOrId(), err)
+
 			stats.skipped++
+
 			continue
 		}
 
@@ -496,7 +500,9 @@ func updateDestinations(ctx context.Context, client *request.APIClient,
 			// Log prompt failures but continue with other destinations
 			logger.Infof("failed to prompt for destination %s update: %v",
 				dest.NameOrId(), err)
+
 			stats.skipped++
+
 			continue
 		}
 
@@ -511,6 +517,7 @@ func updateDestinations(ctx context.Context, client *request.APIClient,
 		if err := updateDestination(ctx, client, dest, publicURL); err != nil {
 			// Log API update failures but continue with other destinations
 			logger.Infof("failed to update destination %s: %v", dest.NameOrId(), err)
+
 			stats.skipped++
 
 			continue


### PR DESCRIPTION
This adds a new command, "sync-ngrok". It will wait for ngrok to be running, figure out what the public URL is, and update one or more Ampersand destinations to point to the ngrok URL (that is, it will swap out the domain - the path will be preserved).

I did this because I got tired of updating destinations by hand every time I had to re-run ngrok for local testing.

https://github.com/user-attachments/assets/66939892-47a8-4deb-ac9c-0abddc77c031
